### PR TITLE
Avx

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ keywords = ["intrinsics", "simd"]
 bytemuck = {version = "1.2", optional = true}
 
 [features]
+license1 = []
+license2 = ["license1"]
+default = []
 
 [profile.test]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,6 @@ keywords = ["intrinsics", "simd"]
 bytemuck = {version = "1.2", optional = true}
 
 [features]
-license1 = []
-license2 = ["license1"]
 default = []
 
 [profile.test]

--- a/README.md
+++ b/README.md
@@ -5,11 +5,20 @@
 
 # safe_arch
 
-Exposes arch-specific intrinsics as safe function (via cfg).
+Exposes arch-specific intrinsics as safe function.
 
-I don't like putting too much in the Readme and also in the crate docs, it can
-get out of sync. Just see the [crate docs](https://docs.rs/safe_arch) for more
-details.
+The crate aims to be _as minimal as possible_. Each intrinsic gets a function or
+macro so that you can safely use it as directly as possible. Essentially no
+additional abstractions are provided, that's not the point of this crate. The
+goal is only to provide safety while getting in the way as little as possible.
+
+All function and macro availability is done purely at compile time via
+`#[cfg()]` attributes on the various modules. If a CPU feature isn't enabled for
+the build then those functions or macros won't be available. If you'd like to
+determine what CPU features are available at runtime and then call different
+code accordingly, this crate is not for you.
+
+See the [crate docs](https://docs.rs/safe_arch) for more details.
 
 * **Minimum Rust:** The CI tests the crate against Stable 1.43.0. The doc-tests
   are known to require at least 1.43 because they use `u32::MAX`, `f32::NAN`,

--- a/src/intel/avx.rs
+++ b/src/intel/avx.rs
@@ -1,0 +1,14 @@
+#![cfg(target_feature = "avx")]
+
+use super::*;
+
+/// ?
+/// ```
+/// # use safe_arch::*;
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn ___(_a: m128, _b: m128) -> m128 {
+  todo!()
+}

--- a/src/intel/avx.rs
+++ b/src/intel/avx.rs
@@ -2,13 +2,300 @@
 
 use super::*;
 
-/// ?
+/// Lanewise `a + b` with `f64` lanes.
 /// ```
 /// # use safe_arch::*;
+/// let a = m256d::from_array([1.0, 2.0, 3.0, 4.0]);
+/// let b = m256d::from_array([5.0, 6.0, 7.0, 8.5]);
+/// let c = add_m256d(a, b).to_array();
+/// assert_eq!(c, [6.0, 8.0, 10.0, 12.5]);
 /// ```
 #[must_use]
 #[inline(always)]
 #[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
-pub fn ___(_a: m128, _b: m128) -> m128 {
-  todo!()
+pub fn add_m256d(a: m256d, b: m256d) -> m256d {
+  m256d(unsafe { _mm256_add_pd(a.0, b.0) })
 }
+
+/// Lanewise `a + b` with `f32` lanes.
+/// ```
+/// # use safe_arch::*;
+/// let a = m256::from_array([1.0, 2.0, 3.0, 4.0, 20.0, 30.0, 40.0, 50.0]);
+/// let b = m256::from_array([5.0, 6.0, 7.0, 8.5, 90.0, 100.0, 110.0, 51.0]);
+/// let c = add_m256(a, b).to_array();
+/// assert_eq!(c, [6.0, 8.0, 10.0, 12.5, 110.0, 130.0, 150.0, 101.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn add_m256(a: m256, b: m256) -> m256 {
+  m256(unsafe { _mm256_add_ps(a.0, b.0) })
+}
+
+/// Alternately, from the top, add `f64` then sub `f64`.
+/// ```
+/// # use safe_arch::*;
+/// let a = m256d::from_array([10.0, 20.0, 30.0, 40.0]);
+/// let b = m256d::from_array([100.0, 200.0, 300.0, 400.0]);
+/// let c = add_sub_m256d(a, b).to_array();
+/// assert_eq!(c, [-90.0, 220.0, -270.0, 440.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn add_sub_m256d(a: m256d, b: m256d) -> m256d {
+  m256d(unsafe { _mm256_addsub_pd(a.0, b.0) })
+}
+
+/// Alternately, from the top, add `f32` then sub `f32`.
+/// ```
+/// # use safe_arch::*;
+/// let a = m256::from_array([10.0, 20.0, 30.0, 40.0, 1.0, 2.0, 3.0, 4.0]);
+/// let b = m256::from_array([1.0, 20.0, 3.0, 40.0, 11.0, 12.0, 13.0, 14.0]);
+/// let c = add_sub_m256(a, b).to_array();
+/// assert_eq!(c, [9.0, 40.0, 27.0, 80.0, -10.0, 14.0, -10.0, 18.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn add_sub_m256(a: m256, b: m256) -> m256 {
+  m256(unsafe { _mm256_addsub_ps(a.0, b.0) })
+}
+
+/// Bitwise `a & b`.
+/// ```
+/// # use safe_arch::*;
+/// let a = m256d::from_array([1.0, 0.0, 1.0, 0.0]);
+/// let b = m256d::from_array([1.0, 1.0, 0.0, 0.0]);
+/// let c = and_m256d(a, b).to_array();
+/// assert_eq!(c, [1.0, 0.0, 0.0, 0.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+pub fn and_m256d(a: m256d, b: m256d) -> m256d {
+  m256d(unsafe { _mm256_and_pd(a.0, b.0) })
+}
+
+/// Bitwise `a & b`.
+/// ```
+/// # use safe_arch::*;
+/// let a = m256::from_array([1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0]);
+/// let b = m256::from_array([1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0]);
+/// let c = and_m256(a, b).to_array();
+/// assert_eq!(c, [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+pub fn and_m256(a: m256, b: m256) -> m256 {
+  m256(unsafe { _mm256_and_ps(a.0, b.0) })
+}
+
+/// Bitwise `(!a) & b`.
+/// ```
+/// # use safe_arch::*;
+/// let a = m256d::from_array([1.0, 0.0, 1.0, 0.0]);
+/// let b = m256d::from_array([1.0, 1.0, 0.0, 0.0]);
+/// let c = and_m256d(a, b).to_array();
+/// assert_eq!(c, [1.0, 0.0, 0.0, 0.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+pub fn andnot_m256d(a: m256d, b: m256d) -> m256d {
+  m256d(unsafe { _mm256_andnot_pd(a.0, b.0) })
+}
+
+/// Bitwise `(!a) & b`.
+/// ```
+/// # use safe_arch::*;
+/// let a = m256::from_array([1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0]);
+/// let b = m256::from_array([1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0]);
+/// let c = and_m256(a, b).to_array();
+/// assert_eq!(c, [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+pub fn andnot_m256(a: m256, b: m256) -> m256 {
+  m256(unsafe { _mm256_andnot_ps(a.0, b.0) })
+}
+
+// _mm256_blend_pd
+// _mm256_blend_ps
+// _mm256_blendv_pd
+// _mm256_blendv_ps
+// _mm256_broadcast_pd
+// _mm256_broadcast_ps
+// _mm256_broadcast_sd
+// _mm_broadcast_ss
+// _mm256_broadcast_ss
+// _mm256_castpd_ps
+// _mm256_castpd_si256
+// _mm256_castpd128_pd256
+// _mm256_castpd256_pd128
+// _mm256_castps_pd
+// _mm256_castps_si256
+// _mm256_castps128_ps256
+// _mm256_castps256_ps128
+// _mm256_castsi128_si256
+// _mm256_castsi256_pd
+// _mm256_castsi256_ps
+// _mm256_castsi256_si128
+// _mm256_ceil_pd
+// _mm256_ceil_ps
+// _mm_cmp_pd
+// _mm256_cmp_pd
+// _mm_cmp_ps
+// _mm256_cmp_ps
+// _mm_cmp_sd
+// _mm_cmp_ss
+// _mm256_cvtepi32_pd
+// _mm256_cvtepi32_ps
+// _mm256_cvtpd_epi32
+// _mm256_cvtpd_ps
+// _mm256_cvtps_epi32
+// _mm256_cvtps_pd
+// _mm256_cvtsd_f64
+// _mm256_cvtsi256_si32
+// _mm256_cvtss_f32
+// _mm256_cvttpd_epi32
+// _mm256_cvttps_epi32
+// _mm256_div_pd
+// _mm256_div_ps
+// _mm256_dp_ps
+// _mm256_extract_epi32
+// _mm256_extract_epi64
+// _mm256_extractf128_pd
+// _mm256_extractf128_ps
+// _mm256_extractf128_si256
+// _mm256_floor_pd
+// _mm256_floor_ps
+// _mm256_hadd_pd
+// _mm256_hadd_ps
+// _mm256_hsub_pd
+// _mm256_hsub_ps
+// _mm256_insert_epi16
+// _mm256_insert_epi32
+// _mm256_insert_epi64
+// _mm256_insert_epi8
+// _mm256_insertf128_pd
+// _mm256_insertf128_ps
+// _mm256_insertf128_si256
+// _mm256_lddqu_si256
+// _mm256_load_pd
+// _mm256_load_ps
+// _mm256_load_si256
+// _mm256_loadu_pd
+// _mm256_loadu_ps
+// _mm256_loadu_si256
+// _mm256_loadu2_m128
+// _mm256_loadu2_m128d
+// _mm256_loadu2_m128i
+// _mm_maskload_pd
+// _mm256_maskload_pd
+// _mm_maskload_ps
+// _mm256_maskload_ps
+// _mm_maskstore_pd
+// _mm256_maskstore_pd
+// _mm_maskstore_ps
+// _mm256_maskstore_ps
+// _mm256_max_pd
+// _mm256_max_ps
+// _mm256_min_pd
+// _mm256_min_ps
+// _mm256_movedup_pd
+// _mm256_movehdup_ps
+// _mm256_moveldup_ps
+// _mm256_movemask_pd
+// _mm256_movemask_ps
+// _mm256_mul_pd
+// _mm256_mul_ps
+// _mm256_or_pd
+// _mm256_or_ps
+// _mm_permute_pd
+// _mm256_permute_pd
+// _mm_permute_ps
+// _mm256_permute_ps
+// _mm256_permute2f128_pd
+// _mm256_permute2f128_ps
+// _mm256_permute2f128_si256
+// _mm_permutevar_pd
+// _mm256_permutevar_pd
+// _mm_permutevar_ps
+// _mm256_permutevar_ps
+// _mm256_rcp_ps
+// _mm256_round_pd
+// _mm256_round_ps
+// _mm256_rsqrt_ps
+// _mm256_set_epi16
+// _mm256_set_epi32
+// _mm256_set_epi64x
+// _mm256_set_epi8
+// _mm256_set_m128
+// _mm256_set_m128d
+// _mm256_set_m128i
+// _mm256_set_pd
+// _mm256_set_ps
+// _mm256_set1_epi16
+// _mm256_set1_epi32
+// _mm256_set1_epi64x
+// _mm256_set1_epi8
+// _mm256_set1_pd
+// _mm256_set1_ps
+// _mm256_setr_epi16
+// _mm256_setr_epi32
+// _mm256_setr_epi64x
+// _mm256_setr_epi8
+// _mm256_setr_m128
+// _mm256_setr_m128d
+// _mm256_setr_m128i
+// _mm256_setr_pd
+// _mm256_setr_ps
+// _mm256_setzero_pd
+// _mm256_setzero_ps
+// _mm256_setzero_si256
+// _mm256_shuffle_pd
+// _mm256_shuffle_ps
+// _mm256_sqrt_pd
+// _mm256_sqrt_ps
+// _mm256_store_pd
+// _mm256_store_ps
+// _mm256_store_si256
+// _mm256_storeu_pd
+// _mm256_storeu_ps
+// _mm256_storeu_si256
+// _mm256_storeu2_m128
+// _mm256_storeu2_m128d
+// _mm256_storeu2_m128i
+// _mm256_stream_pd
+// _mm256_stream_ps
+// _mm256_stream_si256
+// _mm256_sub_pd
+// _mm256_sub_ps
+// _mm_testc_pd
+// _mm256_testc_pd
+// _mm_testc_ps
+// _mm256_testc_ps
+// _mm256_testc_si256
+// _mm_testnzc_pd
+// _mm256_testnzc_pd
+// _mm_testnzc_ps
+// _mm256_testnzc_ps
+// _mm256_testnzc_si256
+// _mm_testz_pd
+// _mm256_testz_pd
+// _mm_testz_ps
+// _mm256_testz_ps
+// _mm256_testz_si256
+// _mm256_undefined_pd
+// _mm256_undefined_ps
+// _mm256_undefined_si256
+// _mm256_unpackhi_pd
+// _mm256_unpackhi_ps
+// _mm256_unpacklo_pd
+// _mm256_unpacklo_ps
+// _mm256_xor_pd
+// _mm256_xor_ps
+// _mm256_zeroall
+// _mm256_zeroupper
+// _mm256_zextpd128_pd256
+// _mm256_zextps128_ps256
+// _mm256_zextsi128_si256

--- a/src/intel/avx.rs
+++ b/src/intel/avx.rs
@@ -909,11 +909,7 @@ pub fn convert_to_i32_m256i_from_m256(a: m256) -> m256i {
 /// ```
 #[must_use]
 #[inline(always)]
-#[cfg(feature = "license1")]
-#[cfg_attr(
-  docs_rs,
-  doc(cfg(all(target_feature = "avx", feature = "license1")))
-)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
 pub fn div_m256d(a: m256d, b: m256d) -> m256d {
   m256d(unsafe { _mm256_div_pd(a.0, b.0) })
 }
@@ -929,11 +925,7 @@ pub fn div_m256d(a: m256d, b: m256d) -> m256d {
 /// ```
 #[must_use]
 #[inline(always)]
-#[cfg(feature = "license1")]
-#[cfg_attr(
-  docs_rs,
-  doc(cfg(all(target_feature = "avx", feature = "license1")))
-)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
 pub fn div_m256(a: m256, b: m256) -> m256 {
   m256(unsafe { _mm256_div_ps(a.0, b.0) })
 }
@@ -952,11 +944,7 @@ pub fn div_m256(a: m256, b: m256) -> m256 {
 /// assert_eq!(c, [110.0, 110.0, 110.0, 110.0, 382.0, 382.0, 382.0, 382.0]);
 /// ```
 #[macro_export]
-#[cfg(feature = "license1")]
-#[cfg_attr(
-  docs_rs,
-  doc(cfg(all(target_feature = "avx", feature = "license1")))
-)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
 macro_rules! dot_product_m256 {
   ($a:expr, $b:expr, $imm:expr) => {{
     let a: m256 = $a;
@@ -1799,11 +1787,7 @@ pub fn move_mask_m256(a: m256) -> i32 {
 /// ```
 #[must_use]
 #[inline(always)]
-#[cfg(feature = "license1")]
-#[cfg_attr(
-  docs_rs,
-  doc(cfg(all(target_feature = "avx", feature = "license1")))
-)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
 pub fn mul_m256d(a: m256d, b: m256d) -> m256d {
   m256d(unsafe { _mm256_mul_pd(a.0, b.0) })
 }
@@ -1818,11 +1802,7 @@ pub fn mul_m256d(a: m256d, b: m256d) -> m256d {
 /// ```
 #[must_use]
 #[inline(always)]
-#[cfg(feature = "license1")]
-#[cfg_attr(
-  docs_rs,
-  doc(cfg(all(target_feature = "avx", feature = "license1")))
-)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
 pub fn mul_m256(a: m256, b: m256) -> m256 {
   m256(unsafe { _mm256_mul_ps(a.0, b.0) })
 }
@@ -2411,89 +2391,901 @@ pub fn reciprocal_sqrt_m256(a: m256) -> m256 {
   m256(unsafe { _mm256_rsqrt_ps(a.0) })
 }
 
-// _mm256_set_epi16
-// _mm256_set_epi32
-// _mm256_set_epi64x
-// _mm256_set_epi8
-// _mm256_set_m128
-// _mm256_set_m128d
-// _mm256_set_m128i
-// _mm256_set_pd
-// _mm256_set_ps
+/// Set `i8` args into an `m256i` lane.
+/// ```
+/// # use safe_arch::*;
+/// let a: [i8; 32] =
+///   set_i8_m256i(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31).into();
+/// assert_eq!(a, [31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+#[rustfmt::skip]
+pub fn set_i8_m256i(
+  e31: i8, e30: i8, e29: i8, e28: i8, e27: i8, e26: i8, e25: i8, e24: i8, e23: i8, e22: i8, e21: i8, e20: i8, e19: i8, e18: i8, e17: i8, e16: i8, e15: i8, e14: i8, e13: i8, e12: i8, e11: i8, e10: i8, e9: i8, e8: i8, e7: i8, e6: i8, e5: i8, e4: i8, e3: i8, e2: i8, e1: i8, e0: i8
+) -> m256i {
+  m256i(unsafe {
+    _mm256_set_epi8(
+      e31, e30, e29, e28, e27, e26, e25, e24, e23, e22, e21, e20, e19, e18, e17, e16, e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5, e4, e3, e2, e1, e0
+    )
+  })
+}
 
-// _mm256_set1_epi16
-// _mm256_set1_epi32
-// _mm256_set1_epi64x
-// _mm256_set1_epi8
-// _mm256_set1_pd
-// _mm256_set1_ps
+/// Set `i16` args into an `m256i` lane.
+/// ```
+/// # use safe_arch::*;
+/// let a: [i16; 16] =
+///   set_i16_m256i(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15).into();
+/// assert_eq!(a, [15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+#[rustfmt::skip]
+pub fn set_i16_m256i(
+  e15: i16, e14: i16, e13: i16, e12: i16, e11: i16, e10: i16, e9: i16, e8: i16,
+  e7: i16, e6: i16, e5: i16, e4: i16, e3: i16, e2: i16, e1: i16, e0: i16,
+) -> m256i {
+  m256i(unsafe {
+    _mm256_set_epi16(
+      e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5, e4, e3, e2, e1, e0,
+    )
+  })
+}
 
-// _mm256_setr_epi16
-// _mm256_setr_epi32
-// _mm256_setr_epi64x
-// _mm256_setr_epi8
-// _mm256_setr_m128
-// _mm256_setr_m128d
-// _mm256_setr_m128i
-// _mm256_setr_pd
-// _mm256_setr_ps
+/// Set `i32` args into an `m256i` lane.
+/// ```
+/// # use safe_arch::*;
+/// let a: [i32; 8] =
+///   set_i32_m256i(0, 1, 2, 3, 4, 5, 6, 7).into();
+/// assert_eq!(a, [7, 6, 5, 4, 3, 2, 1, 0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+#[rustfmt::skip]
+pub fn set_i32_m256i(
+  e7: i32, e6: i32, e5: i32, e4: i32, e3: i32, e2: i32, e1: i32, e0: i32,
+) -> m256i {
+  m256i(unsafe {
+    _mm256_set_epi32(e7, e6, e5, e4, e3, e2, e1, e0)
+  })
+}
 
-// _mm256_setzero_pd
-// _mm256_setzero_ps
-// _mm256_setzero_si256
+/// Set `i64` args into an `m256i` lane.
+/// ```
+/// # use safe_arch::*;
+/// let a: [i64; 4] = set_i64_m256i(0, 1, 2, 3).into();
+/// assert_eq!(a, [3, 2, 1, 0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg(target_arch="x86_86")]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+#[rustfmt::skip]
+pub fn set_i64_m256i(
+  e3: i64, e2: i64, e1: i64, e0: i64,
+) -> m256i {
+  m256i(unsafe { _mm256_set_epi64x(e3, e2, e1, e0) })
+}
 
-// _mm256_shuffle_pd
-// _mm256_shuffle_ps
+/// Set `m128` args into an `m256`.
+/// ```
+/// # use safe_arch::*;
+/// let a = set_m128_m256(
+///   m128::from([7.0, 6.0, 5.0, 4.0]),
+///   m128::from([3.0, 2.0, 1.0, 0.0]),
+/// ).to_array();
+/// assert_eq!(a, [7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0, 0.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg(target_arch="x86_86")]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+#[rustfmt::skip]
+pub fn set_m128_m256(
+  hi: m128, lo: m128
+) -> m256 {
+  m256(unsafe { _mm256_set_m128(hi.0, lo.0) })
+}
 
-// _mm256_sqrt_pd
-// _mm256_sqrt_ps
+/// Set `m128d` args into an `m256d`.
+/// ```
+/// # use safe_arch::*;
+/// let a = set_m128d_m256d(
+///   set_m128d(3.0, 2.0),
+///   set_m128d(1.0, 0.0),
+/// ).to_array();
+/// assert_eq!(a, [0.0, 1.0, 2.0, 3.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+#[rustfmt::skip]
+pub fn set_m128d_m256d(
+  hi: m128d, lo: m128d
+) -> m256d {
+  m256d(unsafe { _mm256_set_m128d(hi.0, lo.0) })
+}
 
-// _mm256_store_pd
-// _mm256_store_ps
-// _mm256_store_si256
+/// Set `m128i` args into an `m256i`.
+/// ```
+/// # use safe_arch::*;
+/// let a: [i64; 4] = set_m128i_m256i(
+///   set_i64_m128i(3_i64, 2),
+///   set_i64_m128i(1_i64, 0),
+/// ).into();
+/// assert_eq!(a, [0_i64, 1, 2, 3]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+#[rustfmt::skip]
+pub fn set_m128i_m256i(
+  hi: m128i, lo: m128i
+) -> m256i {
+  m256i(unsafe { _mm256_set_m128i(hi.0, lo.0) })
+}
 
-// _mm256_storeu_pd
-// _mm256_storeu_ps
-// _mm256_storeu_si256
+/// Set `f64` args into an `m256d` lane.
+/// ```
+/// # use safe_arch::*;
+/// let a = set_m256d(0.0, 1.0, 2.0, 3.0).to_array();
+/// assert_eq!(a, [3.0, 2.0, 1.0, 0.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+#[rustfmt::skip]
+pub fn set_m256d(
+  e3: f64, e2: f64, e1: f64, e0: f64,
+) -> m256d {
+  m256d(unsafe { _mm256_set_pd(e3, e2, e1, e0) })
+}
 
-// _mm256_storeu2_m128
-// _mm256_storeu2_m128d
-// _mm256_storeu2_m128i
+/// Set `f32` args into an `m256` lane.
+/// ```
+/// # use safe_arch::*;
+/// let a =
+///   set_m256(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0).to_array();
+/// assert_eq!(a, [7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0, 0.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+#[rustfmt::skip]
+pub fn set_m256(
+  e7: f32, e6: f32, e5: f32, e4: f32, e3: f32, e2: f32, e1: f32, e0: f32,
+) -> m256 {
+  m256(unsafe {
+    _mm256_set_ps(e7, e6, e5, e4, e3, e2, e1, e0)
+  })
+}
 
-// _mm256_sub_pd
-// _mm256_sub_ps
+/// Splat an `i8` arg into an `m256i` lane.
+/// ```
+/// # use safe_arch::*;
+/// let a: [i8; 32] = set_splat_i8_m256i(56).into();
+/// assert_eq!(a, [56_i8; 32]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn set_splat_i8_m256i(i: i8) -> m256i {
+  m256i(unsafe { _mm256_set1_epi8(i) })
+}
 
-// _mm_testc_pd
-// _mm256_testc_pd
-// _mm_testc_ps
-// _mm256_testc_ps
-// _mm256_testc_si256
+/// Splat an `i16` arg into an `m256i` lane.
+/// ```
+/// # use safe_arch::*;
+/// let a: [i16; 16] = set_splat_i16_m256i(56).into();
+/// assert_eq!(a, [56_i16; 16]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn set_splat_i16_m256i(i: i16) -> m256i {
+  m256i(unsafe { _mm256_set1_epi16(i) })
+}
 
-// _mm_testnzc_pd
-// _mm256_testnzc_pd
-// _mm_testnzc_ps
-// _mm256_testnzc_ps
-// _mm256_testnzc_si256
+/// Splat an `i32` arg into an `m256i` lane.
+/// ```
+/// # use safe_arch::*;
+/// let a: [i32; 8] = set_splat_i32_m256i(56).into();
+/// assert_eq!(a, [56_i32; 8]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn set_splat_i32_m256i(i: i32) -> m256i {
+  m256i(unsafe { _mm256_set1_epi32(i) })
+}
 
-// _mm_testz_pd
-// _mm256_testz_pd
-// _mm_testz_ps
-// _mm256_testz_ps
-// _mm256_testz_si256
+/// Splat an `i64` arg into an `m256i` lane.
+/// ```
+/// # use safe_arch::*;
+/// let a: [i64; 32] = set_splat_i64_m256i(56).into();
+/// assert_eq!(a, [56_i64; 4]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg(target_arch = "x86_86")]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn set_splat_i64_m256i(i: i64) -> m256i {
+  m256i(unsafe { _mm256_set1_epi64x(i) })
+}
 
-// _mm256_unpackhi_pd
-// _mm256_unpackhi_ps
+/// Splat an `f64` arg into an `m256d` lane.
+/// ```
+/// # use safe_arch::*;
+/// let a = set_splat_m256d(56.0).to_array();
+/// assert_eq!(a, [56.0; 4]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg(target_arch = "x86_86")]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn set_splat_m256d(f: f64) -> m256d {
+  m256d(unsafe { _mm256_set1_pd(f) })
+}
 
-// _mm256_unpacklo_pd
-// _mm256_unpacklo_ps
+/// Splat an `f32` arg into an `m256` lane.
+/// ```
+/// # use safe_arch::*;
+/// let a =
+///   set_splat_m256(56.0).to_array();
+/// assert_eq!(a, [56.0; 8]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+#[rustfmt::skip]
+pub fn set_splat_m256(
+  f: f32,
+) -> m256 {
+  m256(unsafe {
+    _mm256_set1_ps(f)
+  })
+}
 
-// _mm256_xor_pd
-// _mm256_xor_ps
+//
+//
+//
 
-// _mm256_zeroall
-// _mm256_zeroupper
+/// Set `i8` args into an `m256i` lane.
+/// ```
+/// # use safe_arch::*;
+/// let a: [i8; 32] =
+///   set_reversed_i8_m256i(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31).into();
+/// assert_eq!(a, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+#[rustfmt::skip]
+pub fn set_reversed_i8_m256i(
+  e31: i8, e30: i8, e29: i8, e28: i8, e27: i8, e26: i8, e25: i8, e24: i8, e23: i8, e22: i8, e21: i8, e20: i8, e19: i8, e18: i8, e17: i8, e16: i8, e15: i8, e14: i8, e13: i8, e12: i8, e11: i8, e10: i8, e9: i8, e8: i8, e7: i8, e6: i8, e5: i8, e4: i8, e3: i8, e2: i8, e1: i8, e0: i8
+) -> m256i {
+  m256i(unsafe {
+    _mm256_setr_epi8(
+      e31, e30, e29, e28, e27, e26, e25, e24, e23, e22, e21, e20, e19, e18, e17, e16, e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5, e4, e3, e2, e1, e0
+    )
+  })
+}
 
-// _mm256_zextpd128_pd256
-// _mm256_zextps128_ps256
-// _mm256_zextsi128_si256
-// TODO: if we have these we should also include the lane truncate ops
+/// Set `i16` args into an `m256i` lane.
+/// ```
+/// # use safe_arch::*;
+/// let a: [i16; 16] =
+///   set_reversed_i16_m256i(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15).into();
+/// assert_eq!(a, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+#[rustfmt::skip]
+pub fn set_reversed_i16_m256i(
+  e15: i16, e14: i16, e13: i16, e12: i16, e11: i16, e10: i16, e9: i16, e8: i16,
+  e7: i16, e6: i16, e5: i16, e4: i16, e3: i16, e2: i16, e1: i16, e0: i16,
+) -> m256i {
+  m256i(unsafe {
+    _mm256_setr_epi16(
+      e15, e14, e13, e12, e11, e10, e9, e8, e7, e6, e5, e4, e3, e2, e1, e0,
+    )
+  })
+}
+
+/// Set `i32` args into an `m256i` lane.
+/// ```
+/// # use safe_arch::*;
+/// let a: [i32; 8] =
+///   set_reversed_i32_m256i(0, 1, 2, 3, 4, 5, 6, 7).into();
+/// assert_eq!(a, [0, 1, 2, 3, 4, 5, 6, 7]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+#[rustfmt::skip]
+pub fn set_reversed_i32_m256i(
+  e7: i32, e6: i32, e5: i32, e4: i32, e3: i32, e2: i32, e1: i32, e0: i32,
+) -> m256i {
+  m256i(unsafe {
+    _mm256_setr_epi32(e7, e6, e5, e4, e3, e2, e1, e0)
+  })
+}
+
+/// Set `i64` args into an `m256i` lane.
+/// ```
+/// # use safe_arch::*;
+/// let a: [i64; 4] = set_reversed_i64_m256i(0, 1, 2, 3).into();
+/// assert_eq!(a, [0, 1, 2, 3]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg(target_arch="x86_86")]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+#[rustfmt::skip]
+pub fn set_reversed_i64_m256i(
+  e3: i64, e2: i64, e1: i64, e0: i64,
+) -> m256i {
+  m256i(unsafe { _mm256_setr_epi64x(e3, e2, e1, e0) })
+}
+
+/// Set `m128` args into an `m256`.
+/// ```
+/// # use safe_arch::*;
+/// let a = set_reversed_m128_m256(
+///   set_reversed_m128(7.0, 6.0, 5.0, 4.0),
+///   set_reversed_m128(3.0, 2.0, 1.0, 0.0),
+/// ).to_array();
+/// assert_eq!(a, [7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0, 0.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg(target_arch="x86_86")]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+#[rustfmt::skip]
+pub fn set_reversed_m128_m256(
+  hi: m128, lo: m128
+) -> m256 {
+  m256(unsafe { _mm256_setr_m128(hi.0, lo.0) })
+}
+
+/// Set `m128d` args into an `m256d`.
+/// ```
+/// # use safe_arch::*;
+/// let a = set_reversed_m128d_m256d(
+///   set_reversed_m128d(3.0, 2.0),
+///   set_reversed_m128d(1.0, 0.0),
+/// ).to_array();
+/// assert_eq!(a, [3.0, 2.0, 1.0, 0.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+#[rustfmt::skip]
+pub fn set_reversed_m128d_m256d(
+  hi: m128d, lo: m128d
+) -> m256d {
+  m256d(unsafe { _mm256_setr_m128d(hi.0, lo.0) })
+}
+
+/// Set `m128i` args into an `m256i`.
+/// ```
+/// # use safe_arch::*;
+/// let a: [i64; 4] = set_reversed_m128i_m256i(
+///   m128i::from([0_i64, 1]),
+///   m128i::from([2_i64, 3]),
+/// ).into();
+/// assert_eq!(a, [0_i64, 1, 2, 3]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+#[rustfmt::skip]
+pub fn set_reversed_m128i_m256i(
+  hi: m128i, lo: m128i
+) -> m256i {
+  m256i(unsafe { _mm256_setr_m128i(hi.0, lo.0) })
+}
+
+/// Set `f64` args into an `m256d` lane.
+/// ```
+/// # use safe_arch::*;
+/// let a = set_reversed_m256d(0.0, 1.0, 2.0, 3.0).to_array();
+/// assert_eq!(a, [0.0, 1.0, 2.0, 3.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+#[rustfmt::skip]
+pub fn set_reversed_m256d(
+  e3: f64, e2: f64, e1: f64, e0: f64,
+) -> m256d {
+  m256d(unsafe { _mm256_setr_pd(e3, e2, e1, e0) })
+}
+
+/// Set `f32` args into an `m256` lane.
+/// ```
+/// # use safe_arch::*;
+/// let a =
+///   set_reversed_m256(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0).to_array();
+/// assert_eq!(a, [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+#[rustfmt::skip]
+pub fn set_reversed_m256(
+  e7: f32, e6: f32, e5: f32, e4: f32, e3: f32, e2: f32, e1: f32, e0: f32,
+) -> m256 {
+  m256(unsafe {
+    _mm256_setr_ps(e7, e6, e5, e4, e3, e2, e1, e0)
+  })
+}
+
+/// A zeroed `m256d`
+/// ```
+/// # use safe_arch::*;
+/// let a = zeroed_m256d().to_array();
+/// assert_eq!(a, [0.0; 4]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn zeroed_m256d() -> m256d {
+  m256d(unsafe { _mm256_setzero_pd() })
+}
+
+/// A zeroed `m256`
+/// ```
+/// # use safe_arch::*;
+/// let a = zeroed_m256().to_array();
+/// assert_eq!(a, [0.0; 8]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn zeroed_m256() -> m256 {
+  m256(unsafe { _mm256_setzero_ps() })
+}
+
+/// A zeroed `m256i`
+/// ```
+/// # use safe_arch::*;
+/// let a: [i32; 8] = zeroed_m256i().into();
+/// assert_eq!(a, [0; 8]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn zeroed_m256i() -> m256i {
+  m256i(unsafe { _mm256_setzero_si256() })
+}
+
+/// Shuffles the `f64` lanes around.
+///
+/// * args are 0 or 1 each, for "low" or "high" within that pairing.
+/// * a 0/1, b 0/1, a 2/3, b 2/3
+/// ```
+/// # use safe_arch::*;
+/// let a = m256d::from_array([1.0, 2.0, 3.0, 4.0]);
+/// let b = m256d::from_array([5.0, 6.0, 7.0, 8.0]);
+/// //
+/// let c = shuffle_m256d!(a, b, 1, 0, 1, 0).to_array();
+/// assert_eq!(c, [2.0, 5.0, 4.0, 7.0]);
+/// ```
+#[macro_export]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+macro_rules! shuffle_m256d {
+  ($a:expr, $b:expr, $z:expr, $o:expr, $t:expr, $e:expr) => {{
+    const MASK: i32 =
+      (($z & 0b1) | ($o & 0b1) << 1 | ($t & 0b1) << 2 | ($e & 0b1) << 3) as i32;
+    let a: m256d = $a;
+    let b: m256d = $b;
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::_mm256_shuffle_pd;
+    #[cfg(target_arch = "x86_64")]
+    use core::arch::x86_64::_mm256_shuffle_pd;
+    m256d(unsafe { _mm256_shuffle_pd(a.0, b.0, MASK) })
+  }};
+}
+
+/// Shuffles the `f32` lanes around.
+///
+/// * args are 0, 1, 2, 3 for which lane to use in the lower or upper half.
+/// * the same pattern is used for the four low lanes and the four high lanes.
+/// * a low, a low, b low, b low, a high, a high, b high, b high
+/// ```
+/// # use safe_arch::*;
+/// let a = m256::from_array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]);
+/// let b = m256::from_array([9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0]);
+/// //
+/// let c = shuffle_m256!(a, b, 1, 3, 2, 0).to_array();
+/// assert_eq!(c, [2.0, 4.0, 11.0, 9.0, 6.0, 8.0, 15.0, 13.0]);
+/// ```
+#[macro_export]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+macro_rules! shuffle_m256 {
+  ($a:expr, $b:expr, $z:expr, $o:expr, $t:expr, $e:expr) => {{
+    const MASK: i32 =
+      (($z & 0b11) | ($o & 0b11) << 2 | ($t & 0b11) << 4 | ($e & 0b11) << 6)
+        as i32;
+    let a: m256 = $a;
+    let b: m256 = $b;
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::_mm256_shuffle_ps;
+    #[cfg(target_arch = "x86_64")]
+    use core::arch::x86_64::_mm256_shuffle_ps;
+    m256(unsafe { _mm256_shuffle_ps(a.0, b.0, MASK) })
+  }};
+}
+
+/// Lanewise `sqrt` on `f64` lanes.
+/// ```
+/// # use safe_arch::*;
+/// let a = m256d::from_array([1.0, 4.0, 9.0, 16.0]);
+/// let b = sqrt_m256d(a).to_array();
+/// assert_eq!(b, [1.0, 2.0, 3.0, 4.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn sqrt_m256d(a: m256d) -> m256d {
+  m256d(unsafe { _mm256_sqrt_pd(a.0) })
+}
+
+/// Lanewise `sqrt` on `f64` lanes.
+/// ```
+/// # use safe_arch::*;
+/// let a = m256::from_array([1.0, 4.0, 9.0, 16.0, 25.0, 36.0, 0.0, 49.0]);
+/// let b = sqrt_m256(a).to_array();
+/// assert_eq!(b, [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 0.0, 7.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn sqrt_m256(a: m256) -> m256 {
+  m256(unsafe { _mm256_sqrt_ps(a.0) })
+}
+
+/// Store data from a register into memory.
+///
+/// ```
+/// # use safe_arch::*;
+/// let mut addr = m256d::from([0.0; 4]);
+/// store_m256d(&mut addr, m256d::from([1.0, 2.0, 3.0, 4.0]));
+/// assert_eq!(addr.to_array(), [1.0, 2.0, 3.0, 4.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn store_m256d(addr: &mut m256d, a: m256d) {
+  unsafe { _mm256_store_pd(addr as *mut m256d as *mut f64, a.0) }
+}
+
+/// Store data from a register into memory.
+///
+/// ```
+/// # use safe_arch::*;
+/// let mut addr = m256::from([0.0; 8]);
+/// store_m256(&mut addr, m256::from([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]));
+/// assert_eq!(addr.to_array(), [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn store_m256(addr: &mut m256, a: m256) {
+  unsafe { _mm256_store_ps(addr as *mut m256 as *mut f32, a.0) }
+}
+
+/// Store data from a register into memory.
+///
+/// ```
+/// # use safe_arch::*;
+/// let mut addr = m256i::from([0_i32; 8]);
+/// store_m256i(&mut addr, m256i::from([1, 2, 3, 4, 5, 6, 7, 8]));
+/// assert_eq!(<[i32; 8]>::from(addr), [1, 2, 3, 4, 5, 6, 7, 8]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn store_m256i(addr: &mut m256i, a: m256i) {
+  unsafe { _mm256_store_si256(addr as *mut m256i as *mut __m256i, a.0) }
+}
+
+/// Store data from a register into memory.
+///
+/// ```
+/// # use safe_arch::*;
+/// let mut addr = [0.0; 4];
+/// store_unaligned_m256d(&mut addr, m256d::from([1.0, 2.0, 3.0, 4.0]));
+/// assert_eq!(addr, [1.0, 2.0, 3.0, 4.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn store_unaligned_m256d(addr: &mut [f64; 4], a: m256d) {
+  unsafe { _mm256_storeu_pd(addr.as_mut_ptr(), a.0) }
+}
+
+/// Store data from a register into memory.
+///
+/// ```
+/// # use safe_arch::*;
+/// let mut addr = [0.0; 8];
+/// store_unaligned_m256(
+///   &mut addr,
+///   m256::from([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]),
+/// );
+/// assert_eq!(addr, [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn store_unaligned_m256(addr: &mut [f32; 8], a: m256) {
+  unsafe { _mm256_storeu_ps(addr.as_mut_ptr(), a.0) }
+}
+
+/// Store data from a register into memory.
+///
+/// ```
+/// # use safe_arch::*;
+/// let mut addr = [0_i8; 32];
+/// store_unaligned_m256i(&mut addr, m256i::from([12_i8; 32]));
+/// assert_eq!(addr, [12_i8; 32]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn store_unaligned_m256i(addr: &mut [i8; 32], a: m256i) {
+  unsafe { _mm256_storeu_si256(addr as *mut [i8; 32] as *mut __m256i, a.0) }
+}
+
+/// Store data from a register into memory.
+///
+/// ```
+/// # use safe_arch::*;
+/// let mut hi_addr = [0.0; 2];
+/// let mut lo_addr = [0.0; 2];
+/// store_unaligned_hi_lo_m256d(
+///   &mut hi_addr,
+///   &mut lo_addr,
+///   m256d::from([1.0, 2.0, 3.0, 4.0]),
+/// );
+/// assert_eq!(hi_addr, [3.0, 4.0]);
+/// assert_eq!(lo_addr, [1.0, 2.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn store_unaligned_hi_lo_m256d(
+  hi_addr: &mut [f64; 2],
+  lo_addr: &mut [f64; 2],
+  a: m256d,
+) {
+  unsafe {
+    _mm256_storeu2_m128d(hi_addr.as_mut_ptr(), lo_addr.as_mut_ptr(), a.0)
+  }
+}
+
+/// Store data from a register into memory.
+///
+/// ```
+/// # use safe_arch::*;
+/// let mut hi_addr = [0.0; 4];
+/// let mut lo_addr = [0.0; 4];
+/// store_unaligned_hi_lo_m256(
+///   &mut hi_addr,
+///   &mut lo_addr,
+///   m256::from([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]),
+/// );
+/// assert_eq!(hi_addr, [5.0, 6.0, 7.0, 8.0]);
+/// assert_eq!(lo_addr, [1.0, 2.0, 3.0, 4.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn store_unaligned_hi_lo_m256(
+  hi_addr: &mut [f32; 4],
+  lo_addr: &mut [f32; 4],
+  a: m256,
+) {
+  unsafe {
+    _mm256_storeu2_m128(hi_addr.as_mut_ptr(), lo_addr.as_mut_ptr(), a.0)
+  }
+}
+
+/// Store data from a register into memory.
+///
+/// ```
+/// # use safe_arch::*;
+/// let mut hi_addr = [0_i8; 16];
+/// let mut lo_addr = [0_i8; 16];
+/// store_unaligned_hi_lo_m256i(
+///   &mut hi_addr,
+///   &mut lo_addr,
+///   m256i::from([56_i8; 32]),
+/// );
+/// assert_eq!(hi_addr, [56_i8; 16]);
+/// assert_eq!(lo_addr, [56_i8; 16]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn store_unaligned_hi_lo_m256i(
+  hi_addr: &mut [i8; 16],
+  lo_addr: &mut [i8; 16],
+  a: m256i,
+) {
+  unsafe {
+    _mm256_storeu2_m128i(
+      hi_addr.as_mut_ptr().cast(),
+      lo_addr.as_mut_ptr().cast(),
+      a.0,
+    )
+  }
+}
+
+/// Lanewise `a - b` with `f64` lanes.
+/// ```
+/// # use safe_arch::*;
+/// let a = m256d::from_array([1.0, 2.0, 3.0, 4.0]);
+/// let b = m256d::from_array([5.0, 60.0, 712.0, 8.5]);
+/// let c = sub_m256d(a, b).to_array();
+/// assert_eq!(c, [-4.0, -58.0, -709.0, -4.5]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn sub_m256d(a: m256d, b: m256d) -> m256d {
+  m256d(unsafe { _mm256_sub_pd(a.0, b.0) })
+}
+
+/// Lanewise `a - b` with `f32` lanes.
+/// ```
+/// # use safe_arch::*;
+/// let a = m256::from_array([1.0, 2.0, 3.0, 4.0, 20.0, 30.0, 40.0, 50.0]);
+/// let b = m256::from_array([59.0, 61.0, 79.0, 81.5, 90.0, 100.0, 110.0, 51.0]);
+/// let c = sub_m256(a, b).to_array();
+/// assert_eq!(c, [-58.0, -59.0, -76.0, -77.5, -70.0, -70.0, -70.0, -1.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn sub_m256(a: m256, b: m256) -> m256 {
+  m256(unsafe { _mm256_sub_ps(a.0, b.0) })
+}
+
+/// Unpack and interleave the high lanes.
+/// ```
+/// # use safe_arch::*;
+/// let a = m256d::from_array([1.0, 2.0, 3.0, 4.0]);
+/// let b = m256d::from_array([59.0, 61.0, 79.0, 81.5]);
+/// let c = unpack_hi_m256d(a, b).to_array();
+/// assert_eq!(c, [2.0, 61.0, 4.0, 81.5]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn unpack_hi_m256d(a: m256d, b: m256d) -> m256d {
+  m256d(unsafe { _mm256_unpackhi_pd(a.0, b.0) })
+}
+
+/// Unpack and interleave the high lanes.
+/// ```
+/// # use safe_arch::*;
+/// let a = m256::from_array([1.0, 2.0, 3.0, 4.0, 20.0, 30.0, 40.0, 50.0]);
+/// let b = m256::from_array([59.0, 61.0, 79.0, 81.5, 90.0, 100.0, 110.0, 51.0]);
+/// let c = unpack_hi_m256(a, b).to_array();
+/// assert_eq!(c, [3.0, 79.0, 4.0, 81.5, 40.0, 110.0, 50.0, 51.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn unpack_hi_m256(a: m256, b: m256) -> m256 {
+  m256(unsafe { _mm256_unpackhi_ps(a.0, b.0) })
+}
+
+/// Unpack and interleave the high lanes.
+/// ```
+/// # use safe_arch::*;
+/// let a = m256d::from_array([1.0, 2.0, 3.0, 4.0]);
+/// let b = m256d::from_array([59.0, 61.0, 79.0, 81.5]);
+/// let c = unpack_lo_m256d(a, b).to_array();
+/// assert_eq!(c, [1.0, 59.0, 3.0, 79.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn unpack_lo_m256d(a: m256d, b: m256d) -> m256d {
+  m256d(unsafe { _mm256_unpacklo_pd(a.0, b.0) })
+}
+
+/// Unpack and interleave the high lanes.
+/// ```
+/// # use safe_arch::*;
+/// let a = m256::from_array([1.0, 2.0, 3.0, 4.0, 20.0, 30.0, 40.0, 50.0]);
+/// let b = m256::from_array([59.0, 61.0, 79.0, 81.5, 90.0, 100.0, 110.0, 51.0]);
+/// let c = unpack_lo_m256(a, b).to_array();
+/// assert_eq!(c, [1.0, 59.0, 2.0, 61.0, 20.0, 90.0, 30.0, 100.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn unpack_lo_m256(a: m256, b: m256) -> m256 {
+  m256(unsafe { _mm256_unpacklo_ps(a.0, b.0) })
+}
+
+/// Bitwise `a ^ b`.
+/// ```
+/// # use safe_arch::*;
+/// let a = m256d::from_array([1.0, 0.0, 1.0, 0.0]);
+/// let b = m256d::from_array([1.0, 1.0, 0.0, 0.0]);
+/// let c = xor_m256d(a, b).to_array();
+/// assert_eq!(c, [0.0, 1.0, 1.0, 0.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn xor_m256d(a: m256d, b: m256d) -> m256d {
+  m256d(unsafe { _mm256_xor_pd(a.0, b.0) })
+}
+
+/// Bitwise `a ^ b`.
+/// ```
+/// # use safe_arch::*;
+/// let a = m256::from_array([1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0]);
+/// let b = m256::from_array([1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0]);
+/// let c = xor_m256(a, b).to_array();
+/// assert_eq!(c, [0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn xor_m256(a: m256, b: m256) -> m256 {
+  m256(unsafe { _mm256_xor_ps(a.0, b.0) })
+}
+
+/// Zero extend an `m128d` to `m256d`
+///
+/// ```
+/// # use safe_arch::*;
+/// let a = zero_extend_m128d(m128d::from_array([1.0, 2.0])).to_array();
+/// assert_eq!(a, [1.0, 2.0, 0.0, 0.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn zero_extend_m128d(a: m128d) -> m256d {
+  m256d(unsafe { _mm256_zextpd128_pd256(a.0) })
+}
+
+/// Zero extend an `m128` to `m256`
+///
+/// ```
+/// # use safe_arch::*;
+/// let a = zero_extend_m128(m128::from_array([1.0, 2.0, 3.0, 4.0])).to_array();
+/// assert_eq!(a, [1.0, 2.0, 3.0, 4.0, 0.0, 0.0, 0.0, 0.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn zero_extend_m128(a: m128) -> m256 {
+  m256(unsafe { _mm256_zextps128_ps256(a.0) })
+}
+
+/// Zero extend an `m128i` to `m256i`
+///
+/// ```
+/// # use safe_arch::*;
+/// let a: [i32; 8] = zero_extend_m128i(m128i::from([1, 2, 3, 4])).into();
+/// assert_eq!(a, [1, 2, 3, 4, 0, 0, 0, 0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn zero_extend_m128i(a: m128i) -> m256i {
+  m256i(unsafe { _mm256_zextsi128_si256(a.0) })
+}

--- a/src/intel/avx.rs
+++ b/src/intel/avx.rs
@@ -733,20 +733,202 @@ macro_rules! cmp_op_mask_m256d {
   }};
 }
 
-// _mm256_cvtepi32_pd
-// _mm256_cvtepi32_ps
-// _mm256_cvtpd_epi32
-// _mm256_cvtpd_ps
-// _mm256_cvtps_epi32
-// _mm256_cvtps_pd
-// _mm256_cvtsd_f64
-// _mm256_cvtsi256_si32
-// _mm256_cvtss_f32
-// _mm256_cvttpd_epi32
-// _mm256_cvttps_epi32
+/// Convert `i32` lanes to be `f64` lanes.
+///
+/// ```
+/// # use safe_arch::*;
+/// let a = m128i::from([4, 5, 6, 7]);
+/// let b = convert_to_m256d_from_i32_m128i(a).to_array();
+/// assert_eq!(b, [4.0, 5.0, 6.0, 7.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn convert_to_m256d_from_i32_m128i(a: m128i) -> m256d {
+  m256d(unsafe { _mm256_cvtepi32_pd(a.0) })
+}
 
-// _mm256_div_pd
-// _mm256_div_ps
+/// Convert `i32` lanes to be `f32` lanes.
+///
+/// ```
+/// # use safe_arch::*;
+/// let a = m256i::from([4, 5, 6, 7, 8, -9, 1, 0]);
+/// let b = convert_to_m256_from_i32_m256i(a).to_array();
+/// assert_eq!(b, [4.0, 5.0, 6.0, 7.0, 8.0, -9.0, 1.0, 0.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn convert_to_m256_from_i32_m256i(a: m256i) -> m256 {
+  m256(unsafe { _mm256_cvtepi32_ps(a.0) })
+}
+
+/// Convert `f64` lanes to be `i32` lanes.
+///
+/// ```
+/// # use safe_arch::*;
+/// let a = m256d::from([4.0, 5.0, 6.0, 7.0]);
+/// let b: [i32; 4] = convert_to_m128i_from_m256d(a).into();
+/// assert_eq!(b, [4, 5, 6, 7]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn convert_to_m128i_from_m256d(a: m256d) -> m128i {
+  m128i(unsafe { _mm256_cvtpd_epi32(a.0) })
+}
+
+/// Convert `f64` lanes to be `f32` lanes.
+///
+/// ```
+/// # use safe_arch::*;
+/// let a = m256d::from([4.0, 5.0, 6.0, 7.0]);
+/// let b = convert_to_m128_from_m256d(a).to_array();
+/// assert_eq!(b, [4.0, 5.0, 6.0, 7.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn convert_to_m128_from_m256d(a: m256d) -> m128 {
+  m128(unsafe { _mm256_cvtpd_ps(a.0) })
+}
+
+/// Convert `f32` lanes to be `i32` lanes.
+///
+/// ```
+/// # use safe_arch::*;
+/// let a = m256::from([4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0]);
+/// let b: [i32; 8] = convert_to_m256i_from_m256(a).into();
+/// assert_eq!(b, [4, 5, 6, 7, 8, 9, 10, 11]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn convert_to_m256i_from_m256(a: m256) -> m256i {
+  m256i(unsafe { _mm256_cvtps_epi32(a.0) })
+}
+
+/// Convert `f32` lanes to be `f64` lanes.
+///
+/// ```
+/// # use safe_arch::*;
+/// let a = m128::from([4.0, 5.0, 6.0, 7.0]);
+/// let b = convert_to_m256d_from_m128(a).to_array();
+/// assert_eq!(b, [4.0, 5.0, 6.0, 7.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn convert_to_m256d_from_m128(a: m128) -> m256d {
+  m256d(unsafe { _mm256_cvtps_pd(a.0) })
+}
+
+/// Convert the lowest `f64` lane to a single `f64`.
+///
+/// ```
+/// # use safe_arch::*;
+/// let a = m256d::from([4.0, 5.0, 6.0, 7.0]);
+/// let b = convert_to_f64_from_m256d_s(a);
+/// assert_eq!(b, 4.0);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn convert_to_f64_from_m256d_s(a: m256d) -> f64 {
+  unsafe { _mm256_cvtsd_f64(a.0) }
+}
+
+/// Convert the lowest `f64` lane to a single `f64`.
+///
+/// ```
+/// # use safe_arch::*;
+/// let a = m256i::from([4, 5, 6, 7, 8, 9, 10, 11]);
+/// let b = convert_to_i32_from_m256i_s(a);
+/// assert_eq!(b, 4);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn convert_to_i32_from_m256i_s(a: m256i) -> i32 {
+  unsafe { _mm256_cvtsi256_si32(a.0) }
+}
+
+/// Convert the lowest `f64` lane to a single `f64`.
+///
+/// ```
+/// # use safe_arch::*;
+/// let a = m256::from([4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0]);
+/// let b = convert_to_f32_from_m256_s(a);
+/// assert_eq!(b, 4.0);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn convert_to_f32_from_m256_s(a: m256) -> f32 {
+  unsafe { _mm256_cvtss_f32(a.0) }
+}
+
+/// Convert `f64` lanes to `i32` lanes.
+///
+/// ```
+/// # use safe_arch::*;
+/// let a = m256d::from([4.0, 5.0, 6.0, 7.0]);
+/// let b: [i32; 4] = convert_to_i32_m128i_from_m256d(a).into();
+/// assert_eq!(b, [4, 5, 6, 7]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn convert_to_i32_m128i_from_m256d(a: m256d) -> m128i {
+  m128i(unsafe { _mm256_cvttpd_epi32(a.0) })
+}
+
+/// Convert `f32` lanes to `i32` lanes.
+///
+/// ```
+/// # use safe_arch::*;
+/// let a = m256::from([4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0]);
+/// let b: [i32; 8] = convert_to_i32_m256i_from_m256(a).into();
+/// assert_eq!(b, [4, 5, 6, 7, 8, 9, 10, 11]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn convert_to_i32_m256i_from_m256(a: m256) -> m256i {
+  m256i(unsafe { _mm256_cvttps_epi32(a.0) })
+}
+
+/// Lanewise `a / b` with `f64`.
+///
+/// ```
+/// # use safe_arch::*;
+/// let a = m256d::from([4.0, 5.0, 6.0, 7.0]);
+/// let b = m256d::from([2.0, 2.0, 3.0, 7.0]);
+/// let c = div_m256d(a, b).to_array();
+/// assert_eq!(c, [2.0, 2.5, 2.0, 1.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn div_m256d(a: m256d, b: m256d) -> m256d {
+  m256d(unsafe { _mm256_div_pd(a.0, b.0) })
+}
+
+/// Lanewise `a / b` with `f32`.
+///
+/// ```
+/// # use safe_arch::*;
+/// let a = m256::from_array([4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0]);
+/// let b = m256::from_array([2.0, 2.0, 3.0, 7.0, 2.0, 3.0, 4.0, 11.0]);
+/// let c = div_m256(a, b).to_array();
+/// assert_eq!(c, [2.0, 2.5, 2.0, 1.0, 4.0, 3.0, 2.5, 1.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn div_m256(a: m256, b: m256) -> m256 {
+  m256(unsafe { _mm256_div_ps(a.0, b.0) })
+}
 
 // _mm256_dp_ps
 

--- a/src/intel/avx.rs
+++ b/src/intel/avx.rs
@@ -909,7 +909,11 @@ pub fn convert_to_i32_m256i_from_m256(a: m256) -> m256i {
 /// ```
 #[must_use]
 #[inline(always)]
-#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+#[cfg(feature = "license1")]
+#[cfg_attr(
+  docs_rs,
+  doc(cfg(all(target_feature = "avx", feature = "license1")))
+)]
 pub fn div_m256d(a: m256d, b: m256d) -> m256d {
   m256d(unsafe { _mm256_div_pd(a.0, b.0) })
 }
@@ -925,7 +929,11 @@ pub fn div_m256d(a: m256d, b: m256d) -> m256d {
 /// ```
 #[must_use]
 #[inline(always)]
-#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+#[cfg(feature = "license1")]
+#[cfg_attr(
+  docs_rs,
+  doc(cfg(all(target_feature = "avx", feature = "license1")))
+)]
 pub fn div_m256(a: m256, b: m256) -> m256 {
   m256(unsafe { _mm256_div_ps(a.0, b.0) })
 }
@@ -944,7 +952,11 @@ pub fn div_m256(a: m256, b: m256) -> m256 {
 /// assert_eq!(c, [110.0, 110.0, 110.0, 110.0, 382.0, 382.0, 382.0, 382.0]);
 /// ```
 #[macro_export]
-#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+#[cfg(feature = "license1")]
+#[cfg_attr(
+  docs_rs,
+  doc(cfg(all(target_feature = "avx", feature = "license1")))
+)]
 macro_rules! dot_product_m256 {
   ($a:expr, $b:expr, $imm:expr) => {{
     let a: m256 = $a;
@@ -1658,6 +1670,7 @@ pub fn store_masked_m256(addr: &mut m256, mask: m256i, a: m256) {
 /// ```
 #[must_use]
 #[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
 pub fn max_m256d(a: m256d, b: m256d) -> m256d {
   m256d(unsafe { _mm256_max_pd(a.0, b.0) })
 }
@@ -1672,6 +1685,7 @@ pub fn max_m256d(a: m256d, b: m256d) -> m256d {
 /// ```
 #[must_use]
 #[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
 pub fn max_m256(a: m256, b: m256) -> m256 {
   m256(unsafe { _mm256_max_ps(a.0, b.0) })
 }
@@ -1686,6 +1700,7 @@ pub fn max_m256(a: m256, b: m256) -> m256 {
 /// ```
 #[must_use]
 #[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
 pub fn min_m256d(a: m256d, b: m256d) -> m256d {
   m256d(unsafe { _mm256_min_pd(a.0, b.0) })
 }
@@ -1700,6 +1715,7 @@ pub fn min_m256d(a: m256d, b: m256d) -> m256d {
 /// ```
 #[must_use]
 #[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
 pub fn min_m256(a: m256, b: m256) -> m256 {
   m256(unsafe { _mm256_min_ps(a.0, b.0) })
 }
@@ -1713,6 +1729,7 @@ pub fn min_m256(a: m256, b: m256) -> m256 {
 /// ```
 #[must_use]
 #[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
 pub fn duplicate_odd_lanes_m256d(a: m256d) -> m256d {
   m256d(unsafe { _mm256_movedup_pd(a.0) })
 }
@@ -1726,6 +1743,7 @@ pub fn duplicate_odd_lanes_m256d(a: m256d) -> m256d {
 /// ```
 #[must_use]
 #[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
 pub fn duplicate_even_lanes_m256(a: m256) -> m256 {
   m256(unsafe { _mm256_movehdup_ps(a.0) })
 }
@@ -1739,39 +1757,659 @@ pub fn duplicate_even_lanes_m256(a: m256) -> m256 {
 /// ```
 #[must_use]
 #[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
 pub fn duplicate_odd_lanes_m256(a: m256) -> m256 {
   m256(unsafe { _mm256_moveldup_ps(a.0) })
 }
 
-// _mm256_movemask_pd
-// _mm256_movemask_ps
+/// Collects the sign bit of each lane into a 4-bit value.
+/// ```
+/// # use safe_arch::*;
+/// assert_eq!(0b0100, move_mask_m256d(m256d::from([1.0, 12.0, -1.0, 3.0])));
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn move_mask_m256d(a: m256d) -> i32 {
+  unsafe { _mm256_movemask_pd(a.0) }
+}
 
-// _mm256_mul_pd
-// _mm256_mul_ps
+/// Collects the sign bit of each lane into a 4-bit value.
+/// ```
+/// # use safe_arch::*;
+/// assert_eq!(
+///   0b00110100,
+///   move_mask_m256(m256::from([1.0, 12.0, -1.0, 3.0, -1.0, -2.0, 3.0, 4.0]))
+/// );
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn move_mask_m256(a: m256) -> i32 {
+  unsafe { _mm256_movemask_ps(a.0) }
+}
 
-// _mm256_or_pd
-// _mm256_or_ps
+/// Lanewise `a * b` with `f64` lanes.
+/// ```
+/// # use safe_arch::*;
+/// let a = m256d::from_array([1.0, 2.0, 3.0, 4.0]);
+/// let b = m256d::from_array([5.0, 6.0, 7.0, 8.5]);
+/// let c = mul_m256d(a, b).to_array();
+/// assert_eq!(c, [5.0, 12.0, 21.0, 34.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg(feature = "license1")]
+#[cfg_attr(
+  docs_rs,
+  doc(cfg(all(target_feature = "avx", feature = "license1")))
+)]
+pub fn mul_m256d(a: m256d, b: m256d) -> m256d {
+  m256d(unsafe { _mm256_mul_pd(a.0, b.0) })
+}
 
-// _mm_permute_pd
-// _mm256_permute_pd
-// _mm_permute_ps
-// _mm256_permute_ps
+/// Lanewise `a * b` with `f32` lanes.
+/// ```
+/// # use safe_arch::*;
+/// let a = m256::from_array([1.0, 2.0, 3.0, 4.0, 20.0, 30.0, 40.0, 50.0]);
+/// let b = m256::from_array([5.0, 6.0, 7.0, 8.5, 90.0, 100.0, 110.0, 51.0]);
+/// let c = mul_m256(a, b).to_array();
+/// assert_eq!(c, [5.0, 12.0, 21.0, 34.0, 1800.0, 3000.0, 4400.0, 2550.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg(feature = "license1")]
+#[cfg_attr(
+  docs_rs,
+  doc(cfg(all(target_feature = "avx", feature = "license1")))
+)]
+pub fn mul_m256(a: m256, b: m256) -> m256 {
+  m256(unsafe { _mm256_mul_ps(a.0, b.0) })
+}
 
-// _mm256_permute2f128_pd
-// _mm256_permute2f128_ps
-// _mm256_permute2f128_si256
+/// Bitwise `a | b`.
+/// ```
+/// # use safe_arch::*;
+/// let a = m256d::from_array([1.0, 1.0, 0.0, 0.0]);
+/// let b = m256d::from_array([1.0, 0.0, 1.0, 0.0]);
+/// let c = or_m256d(a, b).to_array();
+/// assert_eq!(c, [1.0, 1.0, 1.0, 0.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn or_m256d(a: m256d, b: m256d) -> m256d {
+  m256d(unsafe { _mm256_or_pd(a.0, b.0) })
+}
 
-// _mm_permutevar_pd
-// _mm256_permutevar_pd
-// _mm_permutevar_ps
-// _mm256_permutevar_ps
+/// Bitwise `a | b`.
+/// ```
+/// # use safe_arch::*;
+/// let a = m256::from_array([1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0]);
+/// let b = m256::from_array([1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0]);
+/// let c = or_m256(a, b).to_array();
+/// assert_eq!(c, [1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 0.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn or_m256(a: m256, b: m256) -> m256 {
+  m256(unsafe { _mm256_or_ps(a.0, b.0) })
+}
 
-// _mm256_rcp_ps
+/// Permutes the lanes around.
+///
+/// * Different from "shuffle" because there is only one input.
+/// * Generally gives better overall performance than shuffle if it's available
+///   because it reduces register pressure.
+///
+/// This is a macro because the shuffle pattern must be a compile time constant,
+/// and Rust doesn't currently support that for functions.
+///
+/// ```
+/// # use safe_arch::*;
+/// let a = m128d::from_array([1.0, 2.0]);
+/// //
+/// let b = permute_m128d!(a, 0, 0).to_array();
+/// assert_eq!(b, [1.0, 1.0]);
+/// //
+/// let b = permute_m128d!(a, 0, 1).to_array();
+/// assert_eq!(b, [1.0, 2.0]);
+/// //
+/// let b = permute_m128d!(a, 1, 0).to_array();
+/// assert_eq!(b, [2.0, 1.0]);
+/// ```
+#[macro_export]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+macro_rules! permute_m128d {
+  ($a:expr, $z:expr, $o:expr) => {{
+    const MASK: i32 = (($z & 0b1) | ($o & 0b1) << 1) as i32;
+    let a: m128d = $a;
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::_mm_permute_pd;
+    #[cfg(target_arch = "x86_64")]
+    use core::arch::x86_64::_mm_permute_pd;
+    m128d(unsafe { _mm_permute_pd(a.0, MASK) })
+  }};
+}
 
-// _mm256_round_pd
-// _mm256_round_ps
+/// Permutes the lanes around.
+///
+/// * Different from "shuffle" because there is only one input.
+/// * You can't move values between the high and low 128-bit segments.
+/// * Each index is 0 or 1, and selects if you want the index 0 or index 1
+///   element from that 128-bit part of the overall 256 bits.
+/// * Generally gives better overall performance than shuffle if it can
+///   accomplish the movement that you want.
+/// * The shuffle pattern must be a const.
+/// ```
+/// # use safe_arch::*;
+/// let a = m256d::from_array([1.0, 2.0, 3.0, 4.0]);
+/// //
+/// let b = permute_m256d!(a, 0, 0, 0, 0).to_array();
+/// assert_eq!(b, [1.0, 1.0, 3.0, 3.0]);
+/// //
+/// let b = permute_m256d!(a, 0, 1, 0, 1).to_array();
+/// assert_eq!(b, [1.0, 2.0, 3.0, 4.0]);
+/// //
+/// let b = permute_m256d!(a, 1, 0, 1, 1).to_array();
+/// assert_eq!(b, [2.0, 1.0, 4.0, 4.0]);
+/// ```
+#[macro_export]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+macro_rules! permute_m256d {
+  ($a:expr, $z:expr, $o:expr, $t:expr, $h:expr) => {{
+    const MASK: i32 =
+      (($z & 0b1) | ($o & 0b1) << 1 | ($t & 0b1) << 2 | ($h & 0b1) << 3) as i32;
+    let a: m256d = $a;
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::_mm256_permute_pd;
+    #[cfg(target_arch = "x86_64")]
+    use core::arch::x86_64::_mm256_permute_pd;
+    m256d(unsafe { _mm256_permute_pd(a.0, MASK) })
+  }};
+}
 
-// _mm256_rsqrt_ps
+/// Permutes the lanes around.
+///
+/// * Different from "shuffle" because there is only one input.
+/// * Generally gives better overall performance than shuffle if it's available
+///   because it reduces register pressure.
+/// * The permute has to be a const.
+/// ```
+/// # use safe_arch::*;
+/// let a = m128::from_array([1.0, 2.0, 3.0, 4.0]);
+/// //
+/// let b = permute_m128!(a, 0, 0, 0, 0).to_array();
+/// assert_eq!(b, [1.0, 1.0, 1.0, 1.0]);
+/// //
+/// let b = permute_m128!(a, 0, 1, 0, 3).to_array();
+/// assert_eq!(b, [1.0, 2.0, 1.0, 4.0]);
+/// //
+/// let b = permute_m128!(a, 0, 0, 2, 2).to_array();
+/// assert_eq!(b, [1.0, 1.0, 3.0, 3.0]);
+/// ```
+#[macro_export]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+macro_rules! permute_m128 {
+  ($a:expr, $z:expr, $o:expr, $t:expr, $h:expr) => {{
+    const MASK: i32 =
+      (($z & 0b11) | ($o & 0b11) << 2 | ($t & 0b11) << 4 | ($h & 0b11) << 6)
+        as i32;
+    let a: m128 = $a;
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::_mm_permute_ps;
+    #[cfg(target_arch = "x86_64")]
+    use core::arch::x86_64::_mm_permute_ps;
+    m128(unsafe { _mm_permute_ps(a.0, MASK) })
+  }};
+}
+
+/// Permutes the lanes around.
+///
+/// * Different from "shuffle" because there is only one input.
+/// * You can't move values between the high and low 128-bit segments.
+/// * Each index is `0..=3`, and selects the index only from that 128-bit half
+///   of the overall 256 bits involved.
+/// * Generally gives better overall performance than shuffle if it can
+///   accomplish the movement that you want.
+/// * The shuffle pattern must be a const.
+/// ```
+/// # use safe_arch::*;
+/// let a = m256::from_array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]);
+/// //
+/// let b = permute_m256!(a, 0, 0, 0, 0).to_array();
+/// assert_eq!(b, [1.0, 1.0, 1.0, 1.0, 5.0, 5.0, 5.0, 5.0]);
+/// //
+/// let b = permute_m256!(a, 0, 1, 0, 3).to_array();
+/// assert_eq!(b, [1.0, 2.0, 1.0, 4.0, 5.0, 6.0, 5.0, 8.0]);
+/// //
+/// let b = permute_m256!(a, 0, 0, 2, 2).to_array();
+/// assert_eq!(b, [1.0, 1.0, 3.0, 3.0, 5.0, 5.0, 7.0, 7.0]);
+/// ```
+#[macro_export]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+macro_rules! permute_m256 {
+  ($a:expr, $z:expr, $o:expr, $t:expr, $h:expr) => {{
+    const MASK: i32 =
+      (($z & 0b11) | ($o & 0b11) << 2 | ($t & 0b11) << 4 | ($h & 0b11) << 6)
+        as i32;
+    let a: m256 = $a;
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::_mm256_permute_ps;
+    #[cfg(target_arch = "x86_64")]
+    use core::arch::x86_64::_mm256_permute_ps;
+    m256(unsafe { _mm256_permute_ps(a.0, MASK) })
+  }};
+}
+
+/// Permutes the lanes around.
+/// ```
+/// # use safe_arch::*;
+/// let a = m256d::from_array([1.0, 2.0, 3.0, 4.0]);
+/// let b = m256d::from_array([5.0, 6.0, 7.0, 8.0]);
+/// //
+/// let c = permute_f128_in_m256d!(a, b, 2, Clear).to_array();
+/// assert_eq!(c, [5.0, 6.0, 0.0, 0.0]);
+/// //
+/// let c = permute_f128_in_m256d!(a, b, 0, 1).to_array();
+/// assert_eq!(c, [1.0, 2.0, 3.0, 4.0]);
+/// //
+/// let c = permute_f128_in_m256d!(a, b, Clear, 3).to_array();
+/// assert_eq!(c, [0.0, 0.0, 7.0, 8.0]);
+/// ```
+#[macro_export]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+macro_rules! permute_f128_in_m256d {
+  ($a:expr, $b:expr, $low:tt, $high:tt) => {{
+    const MASK: i32 =
+      $crate::permute_f128_in_m256d!(@_convert_tt_to_select $low) |
+      ($crate::permute_f128_in_m256d!(@_convert_tt_to_select $high) << 4);
+    let a: m256d = $a;
+    let b: m256d = $b;
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::_mm256_permute2f128_pd;
+    #[cfg(target_arch = "x86_64")]
+    use core::arch::x86_64::_mm256_permute2f128_pd;
+    m256d(unsafe { _mm256_permute2f128_pd(a.0, b.0, MASK) })
+  }};
+  (@_convert_tt_to_select 0) => {
+    0
+  };
+  (@_convert_tt_to_select 1) => {
+    1
+  };
+  (@_convert_tt_to_select 2) => {
+    2
+  };
+  (@_convert_tt_to_select 3) => {
+    3
+  };
+  (@_convert_tt_to_select Clear) => {
+    0b1000
+  };
+  (@_convert_tt_to_select $unknown:tt) => {
+    compile_error!("Illegal select value, must be 0 ..= 3 or Clear.");
+  };
+}
+
+/// Permutes the lanes around.
+/// ```
+/// # use safe_arch::*;
+/// let a = m256::from_array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]);
+/// let b = m256::from_array([9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0]);
+/// //
+/// let c = permute_f128_in_m256!(a, b, 2, Clear).to_array();
+/// assert_eq!(c, [9.0, 10.0, 11.0, 12.0, 0.0, 0.0, 0.0, 0.0]);
+/// //
+/// let c = permute_f128_in_m256!(a, b, 0, 1).to_array();
+/// assert_eq!(c, [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]);
+/// //
+/// let c = permute_f128_in_m256!(a, b, Clear, 3).to_array();
+/// assert_eq!(c, [0.0, 0.0, 0.0, 0.0, 13.0, 14.0, 15.0, 16.0]);
+/// ```
+#[macro_export]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+macro_rules! permute_f128_in_m256 {
+  ($a:expr, $b:expr, $low:tt, $high:tt) => {{
+  const MASK: i32 = $crate::permute_f128_in_m256!(@_convert_tt_to_select $low)
+    | ($crate::permute_f128_in_m256!(@_convert_tt_to_select $high) << 4);
+    let a: m256 = $a;
+    let b: m256 = $b;
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::_mm256_permute2f128_ps;
+    #[cfg(target_arch = "x86_64")]
+    use core::arch::x86_64::_mm256_permute2f128_ps;
+    m256(unsafe { _mm256_permute2f128_ps(a.0, b.0, MASK) })
+  }};
+  (@_convert_tt_to_select 0) => {
+    0
+  };
+  (@_convert_tt_to_select 1) => {
+    1
+  };
+  (@_convert_tt_to_select 2) => {
+    2
+  };
+  (@_convert_tt_to_select 3) => {
+    3
+  };
+  (@_convert_tt_to_select Clear) => {
+    0b1000
+  };
+  (@_convert_tt_to_select $unknown:tt) => {
+    compile_error!("Illegal select value, must be 0 ..= 3 or Clear.");
+  };
+}
+
+/// Permutes the lanes around.
+/// ```
+/// # use safe_arch::*;
+/// let a = m256i::from([1, 2, 3, 4, 5, 6, 7, 8]);
+/// let b = m256i::from([9, 10, 11, 12, 13, 14, 15, 16]);
+/// //
+/// let c: [i32; 8] = permute_i128_in_m256i!(a, b, 2, Clear).into();
+/// assert_eq!(c, [9, 10, 11, 12, 0, 0, 0, 0]);
+/// //
+/// let c: [i32; 8] = permute_i128_in_m256i!(a, b, 0, 1).into();
+/// assert_eq!(c, [1, 2, 3, 4, 5, 6, 7, 8]);
+/// //
+/// let c: [i32; 8] = permute_i128_in_m256i!(a, b, Clear, 3).into();
+/// assert_eq!(c, [0, 0, 0, 0, 13, 14, 15, 16]);
+/// ```
+#[macro_export]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+macro_rules! permute_i128_in_m256i {
+  ($a:expr, $b:expr, $low:tt, $high:tt) => {{
+  const MASK: i32 = $crate::permute_i128_in_m256i!(@_convert_tt_to_select $low)
+    | ($crate::permute_i128_in_m256i!(@_convert_tt_to_select $high) << 4);
+    let a: m256i = $a;
+    let b: m256i = $b;
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::_mm256_permute2f128_si256;
+    #[cfg(target_arch = "x86_64")]
+    use core::arch::x86_64::_mm256_permute2f128_si256;
+    m256i(unsafe { _mm256_permute2f128_si256(a.0, b.0, MASK) })
+  }};
+  (@_convert_tt_to_select 0) => {
+    0
+  };
+  (@_convert_tt_to_select 1) => {
+    1
+  };
+  (@_convert_tt_to_select 2) => {
+    2
+  };
+  (@_convert_tt_to_select 3) => {
+    3
+  };
+  (@_convert_tt_to_select Clear) => {
+    0b1000
+  };
+  (@_convert_tt_to_select $unknown:tt) => {
+    compile_error!("Illegal select value, must be 0 ..= 3 or Clear.");
+  };
+}
+
+/// Permute with a runtime varying pattern.
+///
+/// For whatever reason, **bit 1** in each `i64` lane is the selection bit.
+/// ```
+/// # use safe_arch::*;
+/// let a = m128d::from_array([2.0, 3.0]);
+/// let b = m128i::from([1_i64 << 1, 0 << 1]);
+/// let c = permute_varying_m128d(a, b).to_array();
+/// assert_eq!(c, [3.0, 2.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn permute_varying_m128d(a: m128d, b: m128i) -> m128d {
+  m128d(unsafe { _mm_permutevar_pd(a.0, b.0) })
+}
+
+/// Permute with a runtime varying pattern.
+///
+/// For whatever reason, **bit 1** in each `i64` lane is the selection bit.
+/// ```
+/// # use safe_arch::*;
+/// let a = m256d::from_array([2.0, 3.0, 7.0, 8.0]);
+/// let b = m256i::from([1_i64 << 1, 0 << 1, 1 << 1, 1 << 1]);
+/// let c = permute_varying_m256d(a, b).to_array();
+/// assert_eq!(c, [3.0, 2.0, 8.0, 8.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn permute_varying_m256d(a: m256d, b: m256i) -> m256d {
+  m256d(unsafe { _mm256_permutevar_pd(a.0, b.0) })
+}
+
+/// Permute with a runtime varying pattern.
+/// ```
+/// # use safe_arch::*;
+/// let a = m128::from_array([0.0, 1.0, 2.0, 3.0]);
+/// let b = m128i::from([0, 2, 3, 1]);
+/// let c = permute_varying_m128(a, b).to_array();
+/// assert_eq!(c, [0.0, 2.0, 3.0, 1.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn permute_varying_m128(a: m128, b: m128i) -> m128 {
+  m128(unsafe { _mm_permutevar_ps(a.0, b.0) })
+}
+
+/// Permute with a runtime varying pattern.
+/// ```
+/// # use safe_arch::*;
+/// let a = m256::from_array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]);
+/// let b = m256i::from([0, 2, 3, 1, 0, 3, 2, 2]);
+/// let c = permute_varying_m256(a, b).to_array();
+/// assert_eq!(c, [0.0, 2.0, 3.0, 1.0, 4.0, 7.0, 6.0, 6.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn permute_varying_m256(a: m256, b: m256i) -> m256 {
+  m256(unsafe { _mm256_permutevar_ps(a.0, b.0) })
+}
+
+/// Reciprocal of `f32` lanes.
+/// ```
+/// # use safe_arch::*;
+/// let a = m256::from_array([1.0, 2.0, 4.0, 8.0, 0.5, 2.0, 8.0, 16.0]);
+/// let b = reciprocal_m256(a).to_array();
+/// let expected = [1.0, 0.5, 0.25, 0.125, 2.0, 0.5, 0.125, 0.0625];
+/// for i in 0..4 {
+///   assert!((b[i] - expected[i]).abs() < 0.001);
+/// }
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn reciprocal_m256(a: m256) -> m256 {
+  m256(unsafe { _mm256_rcp_ps(a.0) })
+}
+
+/// Rounds each lane in the style specified.
+///
+/// ```
+/// # use safe_arch::*;
+/// let a = m256d::from_array([-0.1, 1.6, 2.5, 3.1]);
+/// //
+/// assert_eq!(round_m256d!(a, Nearest).to_array(), [0.0, 2.0, 2.0, 3.0]);
+/// //
+/// assert_eq!(round_m256d!(a, NegInf).to_array(), [-1.0, 1.0, 2.0, 3.0]);
+/// //
+/// assert_eq!(round_m256d!(a, PosInf).to_array(), [0.0, 2.0, 3.0, 4.0]);
+/// //
+/// assert_eq!(round_m256d!(a, Zero).to_array(), [0.0, 1.0, 2.0, 3.0]);
+/// ```
+#[macro_export]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+macro_rules! round_m256d {
+  ($a:expr, Nearest) => {{
+    let a: m256d = $a;
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::{
+      _mm256_round_pd, _MM_FROUND_NO_EXC, _MM_FROUND_TO_NEAREST_INT,
+    };
+    #[cfg(target_arch = "x86_64")]
+    use core::arch::x86_64::{
+      _mm256_round_pd, _MM_FROUND_NO_EXC, _MM_FROUND_TO_NEAREST_INT,
+    };
+    m256d(unsafe {
+      _mm256_round_pd(a.0, _MM_FROUND_NO_EXC | _MM_FROUND_TO_NEAREST_INT)
+    })
+  }};
+  ($a:expr, NegInf) => {{
+    let a: m256d = $a;
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::{
+      _mm256_round_pd, _MM_FROUND_NO_EXC, _MM_FROUND_TO_NEG_INF,
+    };
+    #[cfg(target_arch = "x86_64")]
+    use core::arch::x86_64::{
+      _mm256_round_pd, _MM_FROUND_NO_EXC, _MM_FROUND_TO_NEG_INF,
+    };
+    m256d(unsafe {
+      _mm256_round_pd(a.0, _MM_FROUND_NO_EXC | _MM_FROUND_TO_NEG_INF)
+    })
+  }};
+  ($a:expr, PosInf) => {{
+    let a: m256d = $a;
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::{
+      _mm256_round_pd, _MM_FROUND_NO_EXC, _MM_FROUND_TO_POS_INF,
+    };
+    #[cfg(target_arch = "x86_64")]
+    use core::arch::x86_64::{
+      _mm256_round_pd, _MM_FROUND_NO_EXC, _MM_FROUND_TO_POS_INF,
+    };
+    m256d(unsafe {
+      _mm256_round_pd(a.0, _MM_FROUND_NO_EXC | _MM_FROUND_TO_POS_INF)
+    })
+  }};
+  ($a:expr, Zero) => {{
+    let a: m256d = $a;
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::{
+      _mm256_round_pd, _MM_FROUND_NO_EXC, _MM_FROUND_TO_ZERO,
+    };
+    #[cfg(target_arch = "x86_64")]
+    use core::arch::x86_64::{
+      _mm256_round_pd, _MM_FROUND_NO_EXC, _MM_FROUND_TO_ZERO,
+    };
+    m256d(unsafe {
+      _mm256_round_pd(a.0, _MM_FROUND_NO_EXC | _MM_FROUND_TO_ZERO)
+    })
+  }};
+}
+
+/// Rounds each lane in the style specified.
+///
+/// ```
+/// # use safe_arch::*;
+/// let a = m256::from_array([-0.1, 1.6, 3.3, 4.5, 5.1, 6.5, 7.2, 8.0]);
+/// //
+/// assert_eq!(
+///   round_m256!(a, Nearest).to_array(),
+///   [0.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]
+/// );
+/// //
+/// assert_eq!(
+///   round_m256!(a, NegInf).to_array(),
+///   [-1.0, 1.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]
+/// );
+/// //
+/// assert_eq!(
+///   round_m256!(a, PosInf).to_array(),
+///   [0.0, 2.0, 4.0, 5.0, 6.0, 7.0, 8.0, 8.0]
+/// );
+/// //
+/// assert_eq!(
+///   round_m256!(a, Zero).to_array(),
+///   [0.0, 1.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]
+/// );
+/// ```
+#[macro_export]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+macro_rules! round_m256 {
+  ($a:expr, Nearest) => {{
+    let a: m256 = $a;
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::{
+      _mm256_round_ps, _MM_FROUND_NO_EXC, _MM_FROUND_TO_NEAREST_INT,
+    };
+    #[cfg(target_arch = "x86_64")]
+    use core::arch::x86_64::{
+      _mm256_round_ps, _MM_FROUND_NO_EXC, _MM_FROUND_TO_NEAREST_INT,
+    };
+    m256(unsafe {
+      _mm256_round_ps(a.0, _MM_FROUND_NO_EXC | _MM_FROUND_TO_NEAREST_INT)
+    })
+  }};
+  ($a:expr, NegInf) => {{
+    let a: m256 = $a;
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::{
+      _mm256_round_ps, _MM_FROUND_NO_EXC, _MM_FROUND_TO_NEG_INF,
+    };
+    #[cfg(target_arch = "x86_64")]
+    use core::arch::x86_64::{
+      _mm256_round_ps, _MM_FROUND_NO_EXC, _MM_FROUND_TO_NEG_INF,
+    };
+    m256(unsafe {
+      _mm256_round_ps(a.0, _MM_FROUND_NO_EXC | _MM_FROUND_TO_NEG_INF)
+    })
+  }};
+  ($a:expr, PosInf) => {{
+    let a: m256 = $a;
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::{
+      _mm256_round_ps, _MM_FROUND_NO_EXC, _MM_FROUND_TO_POS_INF,
+    };
+    #[cfg(target_arch = "x86_64")]
+    use core::arch::x86_64::{
+      _mm256_round_ps, _MM_FROUND_NO_EXC, _MM_FROUND_TO_POS_INF,
+    };
+    m256(unsafe {
+      _mm256_round_ps(a.0, _MM_FROUND_NO_EXC | _MM_FROUND_TO_POS_INF)
+    })
+  }};
+  ($a:expr, Zero) => {{
+    let a: m256 = $a;
+    #[cfg(target_arch = "x86")]
+    use core::arch::x86::{
+      _mm256_round_ps, _MM_FROUND_NO_EXC, _MM_FROUND_TO_ZERO,
+    };
+    #[cfg(target_arch = "x86_64")]
+    use core::arch::x86_64::{
+      _mm256_round_ps, _MM_FROUND_NO_EXC, _MM_FROUND_TO_ZERO,
+    };
+    m256(unsafe {
+      _mm256_round_ps(a.0, _MM_FROUND_NO_EXC | _MM_FROUND_TO_ZERO)
+    })
+  }};
+}
+
+/// Reciprocal of `f32` lanes.
+/// ```
+/// # use safe_arch::*;
+/// let a = m256::from_array([16.0, 9.0, 4.0, 25.0, 16.0, 9.0, 4.0, 25.0]);
+/// let b = reciprocal_sqrt_m256(a).to_array();
+/// let expected = [0.25, 0.33333, 0.5, 0.2, 0.25, 0.33333, 0.5, 0.2];
+/// for i in 0..8 {
+///   assert!((b[i] - expected[i]).abs() < 0.001);
+/// }
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn reciprocal_sqrt_m256(a: m256) -> m256 {
+  m256(unsafe { _mm256_rsqrt_ps(a.0) })
+}
 
 // _mm256_set_epi16
 // _mm256_set_epi32

--- a/src/intel/avx.rs
+++ b/src/intel/avx.rs
@@ -944,6 +944,7 @@ pub fn div_m256(a: m256, b: m256) -> m256 {
 /// assert_eq!(c, [110.0, 110.0, 110.0, 110.0, 382.0, 382.0, 382.0, 382.0]);
 /// ```
 #[macro_export]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
 macro_rules! dot_product_m256 {
   ($a:expr, $b:expr, $imm:expr) => {{
     let a: m256 = $a;
@@ -965,6 +966,7 @@ macro_rules! dot_product_m256 {
 /// assert_eq!(extract_i32_from_m256i!(a, 3), 12);
 /// ```
 #[macro_export]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
 macro_rules! extract_i32_from_m256i {
   ($a:expr, $imm:expr) => {{
     let a: m256i = $a;
@@ -985,6 +987,8 @@ macro_rules! extract_i32_from_m256i {
 /// assert_eq!(extract_i64_from_m256i!(a, 1), 10_i64);
 /// ```
 #[macro_export]
+#[cfg(target_arch = "x86_64")]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
 macro_rules! extract_i64_from_m256i {
   ($a:expr, $imm:expr) => {{
     let a: m256i = $a;
@@ -1007,6 +1011,7 @@ macro_rules! extract_i64_from_m256i {
 /// assert_eq!(b, c);
 /// ```
 #[macro_export]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
 macro_rules! extract_m128d_from_m256d {
   ($a:expr, $imm:expr) => {{
     let a: m256d = $a;
@@ -1029,6 +1034,7 @@ macro_rules! extract_m128d_from_m256d {
 /// assert_eq!(b, c);
 /// ```
 #[macro_export]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
 macro_rules! extract_m128_from_m256 {
   ($a:expr, $imm:expr) => {{
     let a: m256 = $a;
@@ -1051,6 +1057,7 @@ macro_rules! extract_m128_from_m256 {
 /// assert_eq!(b, c);
 /// ```
 #[macro_export]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
 macro_rules! extract_m128i_from_m256i {
   ($a:expr, $imm:expr) => {{
     let a: m256i = $a;
@@ -1171,6 +1178,7 @@ pub fn sub_horizontal_m256(a: m256, b: m256) -> m256 {
 /// assert_eq!(b, c);
 /// ```
 #[macro_export]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
 macro_rules! insert_i8_to_m256i {
   ($a:expr, $i:expr, $imm:expr) => {{
     let a: m256i = $a;
@@ -1195,6 +1203,7 @@ macro_rules! insert_i8_to_m256i {
 /// assert_eq!(b, c);
 /// ```
 #[macro_export]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
 macro_rules! insert_i16_to_m256i {
   ($a:expr, $i:expr, $imm:expr) => {{
     let a: m256i = $a;
@@ -1218,6 +1227,7 @@ macro_rules! insert_i16_to_m256i {
 /// assert_eq!(b, c);
 /// ```
 #[macro_export]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
 macro_rules! insert_i32_to_m256i {
   ($a:expr, $i:expr, $imm:expr) => {{
     let a: m256i = $a;
@@ -1241,6 +1251,8 @@ macro_rules! insert_i32_to_m256i {
 /// assert_eq!(b, c);
 /// ```
 #[macro_export]
+#[cfg(target_arch = "x86_64")]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
 macro_rules! insert_i64_to_m256i {
   ($a:expr, $i:expr, $imm:expr) => {{
     let a: m256i = $a;
@@ -1264,6 +1276,7 @@ macro_rules! insert_i64_to_m256i {
 /// assert_eq!(b, [0.0, 0.0, 3.0, 4.0]);
 /// ```
 #[macro_export]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
 macro_rules! insert_m128d_to_m256d {
   ($a:expr, $b:expr, $imm:expr) => {{
     let a: m256d = $a;
@@ -1287,6 +1300,7 @@ macro_rules! insert_m128d_to_m256d {
 /// assert_eq!(b, [0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 4.0]);
 /// ```
 #[macro_export]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
 macro_rules! insert_m128_to_m256 {
   ($a:expr, $b:expr, $imm:expr) => {{
     let a: m256 = $a;
@@ -1310,6 +1324,7 @@ macro_rules! insert_m128_to_m256 {
 /// assert_eq!(b, [0, 0, 0, 0, 1, 2, 3, 4]);
 /// ```
 #[macro_export]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
 macro_rules! insert_m128i_to_m256i {
   ($a:expr, $b:expr, $imm:expr) => {{
     let a: m256i = $a;

--- a/src/intel/avx.rs
+++ b/src/intel/avx.rs
@@ -296,26 +296,137 @@ pub fn cast_from_m256d_to_m256(a: m256d) -> m256 {
   m256(unsafe { _mm256_castpd_ps(a.0) })
 }
 
-//
-// _mm256_castpd_si256
-// _mm256_castpd128_pd256
-// _mm256_castpd256_pd128
-// _mm256_castps_pd
-// _mm256_castps_si256
-// _mm256_castps128_ps256
-// _mm256_castps256_ps128
-// _mm256_castsi128_si256
-// _mm256_castsi256_pd
-// _mm256_castsi256_ps
-// _mm256_castsi256_si128
-// _mm256_ceil_pd
-// _mm256_ceil_ps
+/// Bit-preserving cast from `m256d` to `m256i`.
+///
+/// ```
+/// # use safe_arch::*;
+/// let a = load_f64_splat_m256d(&1.0);
+/// let b: [u32; 8] = cast_from_m256d_to_m256i(a).into();
+/// assert_eq!(
+///   b,
+///   [0, 0x3FF0_0000, 0, 0x3FF0_0000, 0, 0x3FF0_0000, 0, 0x3FF0_0000]
+/// );
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn cast_from_m256d_to_m256i(a: m256d) -> m256i {
+  m256i(unsafe { _mm256_castpd_si256(a.0) })
+}
+
+/// Bit-preserving cast from `m256` to `m256i`.
+///
+/// ```
+/// # use safe_arch::*;
+/// let a = load_f32_splat_m256(&1.0);
+/// let b: [u64; 4] = cast_from_m256_to_m256d(a).to_bits();
+/// assert_eq!(
+///   b,
+///   [
+///     0x3f800000_3f800000,
+///     0x3f800000_3f800000,
+///     0x3f800000_3f800000,
+///     0x3f800000_3f800000,
+///   ]
+/// );
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn cast_from_m256_to_m256d(a: m256) -> m256d {
+  m256d(unsafe { _mm256_castps_pd(a.0) })
+}
+
+/// Bit-preserving cast from `m256` to `m256i`.
+///
+/// ```
+/// # use safe_arch::*;
+/// let a = load_f32_splat_m256(&1.0);
+/// let b: [u64; 4] = cast_from_m256_to_m256i(a).into();
+/// assert_eq!(
+///   b,
+///   [
+///     0x3f800000_3f800000,
+///     0x3f800000_3f800000,
+///     0x3f800000_3f800000,
+///     0x3f800000_3f800000,
+///   ]
+/// );
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn cast_from_m256_to_m256i(a: m256) -> m256i {
+  m256i(unsafe { _mm256_castps_si256(a.0) })
+}
+
+/// Bit-preserving cast from `m256i` to `m256d`.
+///
+/// ```
+/// # use safe_arch::*;
+/// let a = m256i::from([1.0_f64.to_bits(); 4]);
+/// let b = cast_from_m256i_to_m256d(a).to_array();
+/// assert_eq!(b, [1.0; 4]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn cast_from_m256i_to_m256d(a: m256i) -> m256d {
+  m256d(unsafe { _mm256_castsi256_pd(a.0) })
+}
+
+/// Bit-preserving cast from `m256i` to `m256`.
+///
+/// ```
+/// # use safe_arch::*;
+/// let a = m256i::from([1.0_f32.to_bits(); 8]);
+/// let b = cast_from_m256i_to_m256(a).to_array();
+/// assert_eq!(b, [1.0; 8]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn cast_from_m256i_to_m256(a: m256i) -> m256 {
+  m256(unsafe { _mm256_castsi256_ps(a.0) })
+}
+
+/// Round `f64` lanes towards positive infinity.
+///
+/// ```
+/// # use safe_arch::*;
+/// let a = m256d::from([1.1, 2.5, 3.8, 5.0]);
+/// let b = ceil_m256d(a).to_array();
+/// assert_eq!(b, [2.0, 3.0, 4.0, 5.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn ceil_m256d(a: m256d) -> m256d {
+  m256d(unsafe { _mm256_ceil_pd(a.0) })
+}
+
+/// Round `f32` lanes towards positive infinity.
+///
+/// ```
+/// # use safe_arch::*;
+/// let a = m256::from([1.1, 2.5, 3.8, 5.0, -0.5, -1.1, -2.7, -3.0]);
+/// let b = ceil_m256(a).to_array();
+/// assert_eq!(b, [2.0, 3.0, 4.0, 5.0, 0.0, -1.0, -2.0, -3.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn ceil_m256(a: m256) -> m256 {
+  m256(unsafe { _mm256_ceil_ps(a.0) })
+}
+
 // _mm_cmp_pd
 // _mm256_cmp_pd
 // _mm_cmp_ps
 // _mm256_cmp_ps
 // _mm_cmp_sd
 // _mm_cmp_ss
+
 // _mm256_cvtepi32_pd
 // _mm256_cvtepi32_ps
 // _mm256_cvtpd_epi32
@@ -327,20 +438,27 @@ pub fn cast_from_m256d_to_m256(a: m256d) -> m256 {
 // _mm256_cvtss_f32
 // _mm256_cvttpd_epi32
 // _mm256_cvttps_epi32
+
 // _mm256_div_pd
 // _mm256_div_ps
+
 // _mm256_dp_ps
+
 // _mm256_extract_epi32
 // _mm256_extract_epi64
 // _mm256_extractf128_pd
 // _mm256_extractf128_ps
 // _mm256_extractf128_si256
+
 // _mm256_floor_pd
 // _mm256_floor_ps
+
 // _mm256_hadd_pd
 // _mm256_hadd_ps
+
 // _mm256_hsub_pd
 // _mm256_hsub_ps
+
 // _mm256_insert_epi16
 // _mm256_insert_epi32
 // _mm256_insert_epi64
@@ -348,52 +466,73 @@ pub fn cast_from_m256d_to_m256(a: m256d) -> m256 {
 // _mm256_insertf128_pd
 // _mm256_insertf128_ps
 // _mm256_insertf128_si256
+
 // _mm256_lddqu_si256
+
 // _mm256_load_pd
 // _mm256_load_ps
 // _mm256_load_si256
+
 // _mm256_loadu_pd
 // _mm256_loadu_ps
 // _mm256_loadu_si256
+
 // _mm256_loadu2_m128
 // _mm256_loadu2_m128d
 // _mm256_loadu2_m128i
+
 // _mm_maskload_pd
 // _mm256_maskload_pd
 // _mm_maskload_ps
 // _mm256_maskload_ps
+
 // _mm_maskstore_pd
 // _mm256_maskstore_pd
 // _mm_maskstore_ps
 // _mm256_maskstore_ps
+
 // _mm256_max_pd
 // _mm256_max_ps
+
 // _mm256_min_pd
 // _mm256_min_ps
+
 // _mm256_movedup_pd
+
 // _mm256_movehdup_ps
+
 // _mm256_moveldup_ps
+
 // _mm256_movemask_pd
 // _mm256_movemask_ps
+
 // _mm256_mul_pd
 // _mm256_mul_ps
+
 // _mm256_or_pd
 // _mm256_or_ps
+
 // _mm_permute_pd
 // _mm256_permute_pd
 // _mm_permute_ps
 // _mm256_permute_ps
+
 // _mm256_permute2f128_pd
 // _mm256_permute2f128_ps
 // _mm256_permute2f128_si256
+
 // _mm_permutevar_pd
 // _mm256_permutevar_pd
 // _mm_permutevar_ps
 // _mm256_permutevar_ps
+
 // _mm256_rcp_ps
+
 // _mm256_round_pd
 // _mm256_round_ps
+
 // _mm256_rsqrt_ps
+
 // _mm256_set_epi16
 // _mm256_set_epi32
 // _mm256_set_epi64x
@@ -403,12 +542,14 @@ pub fn cast_from_m256d_to_m256(a: m256d) -> m256 {
 // _mm256_set_m128i
 // _mm256_set_pd
 // _mm256_set_ps
+
 // _mm256_set1_epi16
 // _mm256_set1_epi32
 // _mm256_set1_epi64x
 // _mm256_set1_epi8
 // _mm256_set1_pd
 // _mm256_set1_ps
+
 // _mm256_setr_epi16
 // _mm256_setr_epi32
 // _mm256_setr_epi64x
@@ -418,53 +559,70 @@ pub fn cast_from_m256d_to_m256(a: m256d) -> m256 {
 // _mm256_setr_m128i
 // _mm256_setr_pd
 // _mm256_setr_ps
+
 // _mm256_setzero_pd
 // _mm256_setzero_ps
 // _mm256_setzero_si256
+
 // _mm256_shuffle_pd
 // _mm256_shuffle_ps
+
 // _mm256_sqrt_pd
 // _mm256_sqrt_ps
+
 // _mm256_store_pd
 // _mm256_store_ps
 // _mm256_store_si256
+
 // _mm256_storeu_pd
 // _mm256_storeu_ps
 // _mm256_storeu_si256
+
 // _mm256_storeu2_m128
 // _mm256_storeu2_m128d
 // _mm256_storeu2_m128i
+
 // _mm256_stream_pd
 // _mm256_stream_ps
 // _mm256_stream_si256
+
 // _mm256_sub_pd
 // _mm256_sub_ps
+
 // _mm_testc_pd
 // _mm256_testc_pd
 // _mm_testc_ps
 // _mm256_testc_ps
 // _mm256_testc_si256
+
 // _mm_testnzc_pd
 // _mm256_testnzc_pd
 // _mm_testnzc_ps
 // _mm256_testnzc_ps
 // _mm256_testnzc_si256
+
 // _mm_testz_pd
 // _mm256_testz_pd
 // _mm_testz_ps
 // _mm256_testz_ps
 // _mm256_testz_si256
+
 // _mm256_undefined_pd
 // _mm256_undefined_ps
 // _mm256_undefined_si256
+
 // _mm256_unpackhi_pd
 // _mm256_unpackhi_ps
+
 // _mm256_unpacklo_pd
 // _mm256_unpacklo_ps
+
 // _mm256_xor_pd
 // _mm256_xor_ps
+
 // _mm256_zeroall
 // _mm256_zeroupper
+
 // _mm256_zextpd128_pd256
 // _mm256_zextps128_ps256
 // _mm256_zextsi128_si256

--- a/src/intel/avx.rs
+++ b/src/intel/avx.rs
@@ -554,7 +554,6 @@ macro_rules! comparison_operator_translation {
 /// ```
 #[macro_export]
 #[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
-#[cfg(target_feature = "sse")]
 macro_rules! cmp_op_mask_m128 {
   ($a:expr, $op:tt, $b:expr) => {{
     $crate::cmp_op_mask_m128!(
@@ -933,3 +932,4 @@ macro_rules! cmp_op_mask_m256d {
 // _mm256_zextpd128_pd256
 // _mm256_zextps128_ps256
 // _mm256_zextsi128_si256
+// TODO: if we have these we should also include the lane truncate ops

--- a/src/intel/avx.rs
+++ b/src/intel/avx.rs
@@ -219,12 +219,84 @@ pub fn blend_varying_m256(a: m256, b: m256, mask: m256) -> m256 {
   m256(unsafe { _mm256_blendv_ps(a.0, b.0, mask.0) })
 }
 
-// _mm256_broadcast_pd
-// _mm256_broadcast_ps
-// _mm256_broadcast_sd
-// _mm_broadcast_ss
-// _mm256_broadcast_ss
-// _mm256_castpd_ps
+/// Load an `m128d` and splat it to the lower and upper half of an `m256d`
+///
+/// ```
+/// # use safe_arch::*;
+/// let a = m128d::from_array([0.0, 1.0]);
+/// let b = load_m128d_splat_m256d(&a).to_array();
+/// assert_eq!(b, [0.0, 1.0, 0.0, 1.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn load_m128d_splat_m256d(a: &m128d) -> m256d {
+  m256d(unsafe { _mm256_broadcast_pd(&a.0) })
+}
+
+/// Load an `m128` and splat it to the lower and upper half of an `m256`
+///
+/// ```
+/// # use safe_arch::*;
+/// let a = m128::from_array([0.0, 1.0, 2.0, 3.0]);
+/// let b = load_m128_splat_m256(&a).to_array();
+/// assert_eq!(b, [0.0, 1.0, 2.0, 3.0, 0.0, 1.0, 2.0, 3.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn load_m128_splat_m256(a: &m128) -> m256 {
+  m256(unsafe { _mm256_broadcast_ps(&a.0) })
+}
+
+/// Load an `f64` and splat it to all lanes of an `m256d`
+///
+/// ```
+/// # use safe_arch::*;
+/// let a = 1.0;
+/// let b = load_f64_splat_m256d(&a).to_array();
+/// assert_eq!(b, [1.0, 1.0, 1.0, 1.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn load_f64_splat_m256d(a: &f64) -> m256d {
+  m256d(unsafe { _mm256_broadcast_sd(&a) })
+}
+
+/// Load an `f32` and splat it to all lanes of an `m256d`
+///
+/// ```
+/// # use safe_arch::*;
+/// let a = 1.0;
+/// let b = load_f32_splat_m256(&a).to_array();
+/// assert_eq!(b, [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn load_f32_splat_m256(a: &f32) -> m256 {
+  m256(unsafe { _mm256_broadcast_ss(&a) })
+}
+
+/// Bit-preserving cast from `m256d` to `m256`.
+///
+/// ```
+/// # use safe_arch::*;
+/// let a = load_f64_splat_m256d(&1.0);
+/// assert_eq!(
+///   cast_from_m256d_to_m256(a).to_bits(),
+///   [0, 0x3FF0_0000, 0, 0x3FF0_0000, 0, 0x3FF0_0000, 0, 0x3FF0_0000]
+/// );
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn cast_from_m256d_to_m256(a: m256d) -> m256 {
+  m256(unsafe { _mm256_castpd_ps(a.0) })
+}
+
+//
 // _mm256_castpd_si256
 // _mm256_castpd128_pd256
 // _mm256_castpd256_pd128

--- a/src/intel/avx.rs
+++ b/src/intel/avx.rs
@@ -1564,22 +1564,184 @@ pub fn load_masked_m256(a: &m256, mask: m256i) -> m256 {
   m256(unsafe { _mm256_maskload_ps(a as *const m256 as *const f32, mask.0) })
 }
 
-// _mm_maskstore_pd
-// _mm256_maskstore_pd
-// _mm_maskstore_ps
-// _mm256_maskstore_ps
+/// Store data from a register into memory according to a mask.
+///
+/// When the high bit of a mask lane isn't set that lane is not written.
+///
+/// ```
+/// # use safe_arch::*;
+/// let mut a = m128d::default();
+/// store_masked_m128d(
+///   &mut a,
+///   m128i::from([0_i64, -1]),
+///   m128d::from([8.0, 17.0]),
+/// );
+/// assert_eq!(a.to_array(), [0.0, 17.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn store_masked_m128d(addr: &mut m128d, mask: m128i, a: m128d) {
+  unsafe { _mm_maskstore_pd(addr as *mut m128d as *mut f64, mask.0, a.0) }
+}
 
-// _mm256_max_pd
-// _mm256_max_ps
+/// Store data from a register into memory according to a mask.
+///
+/// When the high bit of a mask lane isn't set that lane is not written.
+///
+/// ```
+/// # use safe_arch::*;
+/// let mut a = m256d::default();
+/// store_masked_m256d(
+///   &mut a,
+///   m256i::from([0_i64, -1, -1, 0]),
+///   m256d::from([8.0, 17.0, 16.0, 20.0]),
+/// );
+/// assert_eq!(a.to_array(), [0.0, 17.0, 16.0, 0.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn store_masked_m256d(addr: &mut m256d, mask: m256i, a: m256d) {
+  unsafe { _mm256_maskstore_pd(addr as *mut m256d as *mut f64, mask.0, a.0) }
+}
 
-// _mm256_min_pd
-// _mm256_min_ps
+/// Store data from a register into memory according to a mask.
+///
+/// When the high bit of a mask lane isn't set that lane is not written.
+///
+/// ```
+/// # use safe_arch::*;
+/// let mut a = m128::default();
+/// store_masked_m128(
+///   &mut a,
+///   m128i::from([0, -1, -1, 0]),
+///   m128::from([8.0, 17.0, 16.0, 20.0]),
+/// );
+/// assert_eq!(a.to_array(), [0.0, 17.0, 16.0, 0.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn store_masked_m128(addr: &mut m128, mask: m128i, a: m128) {
+  unsafe { _mm_maskstore_ps(addr as *mut m128 as *mut f32, mask.0, a.0) }
+}
 
-// _mm256_movedup_pd
+/// Store data from a register into memory according to a mask.
+///
+/// When the high bit of a mask lane isn't set that lane is not written.
+///
+/// ```
+/// # use safe_arch::*;
+/// let mut a = m256::default();
+/// store_masked_m256(
+///   &mut a,
+///   m256i::from([0, -1, -1, 0, -1, -1, 0, 0]),
+///   m256::from([8.0, 17.0, 16.0, 20.0, 80.0, 1.0, 2.0, 3.0]),
+/// );
+/// assert_eq!(a.to_array(), [0.0, 17.0, 16.0, 0.0, 80.0, 1.0, 0.0, 0.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "avx")))]
+pub fn store_masked_m256(addr: &mut m256, mask: m256i, a: m256) {
+  unsafe { _mm256_maskstore_ps(addr as *mut m256 as *mut f32, mask.0, a.0) }
+}
 
-// _mm256_movehdup_ps
+/// Lanewise `max(a, b)`.
+/// ```
+/// # use safe_arch::*;
+/// let a = m256d::from_array([1.0, 12.0, -1.0, 3.0]);
+/// let b = m256d::from_array([5.0, 6.0, -0.5, 2.2]);
+/// let c = max_m256d(a, b).to_array();
+/// assert_eq!(c, [5.0, 12.0, -0.5, 3.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+pub fn max_m256d(a: m256d, b: m256d) -> m256d {
+  m256d(unsafe { _mm256_max_pd(a.0, b.0) })
+}
 
-// _mm256_moveldup_ps
+/// Lanewise `max(a, b)`.
+/// ```
+/// # use safe_arch::*;
+/// let a = m256::from_array([1.0, 12.0, -1.0, 3.0, 10.0, 0.0, 1.0, 2.0]);
+/// let b = m256::from_array([5.0, 6.0, -0.5, 2.2, 5.0, 6.0, 7.0, 8.0]);
+/// let c = max_m256(a, b).to_array();
+/// assert_eq!(c, [5.0, 12.0, -0.5, 3.0, 10.0, 6.0, 7.0, 8.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+pub fn max_m256(a: m256, b: m256) -> m256 {
+  m256(unsafe { _mm256_max_ps(a.0, b.0) })
+}
+
+/// Lanewise `min(a, b)`.
+/// ```
+/// # use safe_arch::*;
+/// let a = m256d::from_array([1.0, 12.0, -1.0, 3.0]);
+/// let b = m256d::from_array([5.0, 6.0, -0.5, 2.2]);
+/// let c = min_m256d(a, b).to_array();
+/// assert_eq!(c, [1.0, 6.0, -1.0, 2.2]);
+/// ```
+#[must_use]
+#[inline(always)]
+pub fn min_m256d(a: m256d, b: m256d) -> m256d {
+  m256d(unsafe { _mm256_min_pd(a.0, b.0) })
+}
+
+/// Lanewise `min(a, b)`.
+/// ```
+/// # use safe_arch::*;
+/// let a = m256::from_array([1.0, 12.0, -1.0, 3.0, 10.0, 0.0, 1.0, 2.0]);
+/// let b = m256::from_array([5.0, 6.0, -0.5, 2.2, 5.0, 6.0, 7.0, 8.0]);
+/// let c = min_m256(a, b).to_array();
+/// assert_eq!(c, [1.0, 6.0, -1.0, 2.2, 5.0, 0.0, 1.0, 2.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+pub fn min_m256(a: m256, b: m256) -> m256 {
+  m256(unsafe { _mm256_min_ps(a.0, b.0) })
+}
+
+/// Duplicate the odd-indexed lanes to the even lanes.
+/// ```
+/// # use safe_arch::*;
+/// let a = m256d::from_array([1.0, 12.0, -1.0, 3.0]);
+/// let c = duplicate_odd_lanes_m256d(a).to_array();
+/// assert_eq!(c, [1.0, 1.0, -1.0, -1.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+pub fn duplicate_odd_lanes_m256d(a: m256d) -> m256d {
+  m256d(unsafe { _mm256_movedup_pd(a.0) })
+}
+
+/// Duplicate the even-indexed lanes to the odd lanes.
+/// ```
+/// # use safe_arch::*;
+/// let a = m256::from_array([1.0, 12.0, -1.0, 3.0, 0.0, 7.0, 2.0, 50.0]);
+/// let c = duplicate_even_lanes_m256(a).to_array();
+/// assert_eq!(c, [12.0, 12.0, 3.0, 3.0, 7.0, 7.0, 50.0, 50.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+pub fn duplicate_even_lanes_m256(a: m256) -> m256 {
+  m256(unsafe { _mm256_movehdup_ps(a.0) })
+}
+
+/// Duplicate the odd-indexed lanes to the even lanes.
+/// ```
+/// # use safe_arch::*;
+/// let a = m256::from_array([1.0, 12.0, -1.0, 3.0, 0.0, 7.0, 2.0, 50.0]);
+/// let c = duplicate_odd_lanes_m256(a).to_array();
+/// assert_eq!(c, [1.0, 1.0, -1.0, -1.0, 0.0, 0.0, 2.0, 2.0]);
+/// ```
+#[must_use]
+#[inline(always)]
+pub fn duplicate_odd_lanes_m256(a: m256) -> m256 {
+  m256(unsafe { _mm256_moveldup_ps(a.0) })
+}
 
 // _mm256_movemask_pd
 // _mm256_movemask_ps
@@ -1659,10 +1821,6 @@ pub fn load_masked_m256(a: &m256, mask: m256i) -> m256 {
 // _mm256_storeu2_m128
 // _mm256_storeu2_m128d
 // _mm256_storeu2_m128i
-
-// _mm256_stream_pd
-// _mm256_stream_ps
-// _mm256_stream_si256
 
 // _mm256_sub_pd
 // _mm256_sub_ps

--- a/src/intel/lzcnt.rs
+++ b/src/intel/lzcnt.rs
@@ -10,7 +10,7 @@ use super::*;
 /// ```
 #[must_use]
 #[inline(always)]
-#[cfg_attr(docs_rs, doc(cfg(target_feature = "sse")))]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "lzcnt")))]
 pub fn leading_zero_count_u32(a: u32) -> u32 {
   unsafe { _lzcnt_u32(a) }
 }
@@ -24,7 +24,7 @@ pub fn leading_zero_count_u32(a: u32) -> u32 {
 #[must_use]
 #[inline(always)]
 #[cfg(target_arch = "x86_64")]
-#[cfg_attr(docs_rs, doc(cfg(target_feature = "sse")))]
+#[cfg_attr(docs_rs, doc(cfg(target_feature = "lzcnt")))]
 pub fn leading_zero_count_u64(a: u64) -> u64 {
   unsafe { _lzcnt_u64(a) }
 }

--- a/src/intel/m128d_.rs
+++ b/src/intel/m128d_.rs
@@ -23,7 +23,7 @@ unsafe impl bytemuck::Pod for m128d {}
 unsafe impl bytemuck::TransparentWrapper<__m128d> for m128d {}
 
 #[test]
-fn test_m128_size_align() {
+fn test_m128d_size_align() {
   assert_eq!(core::mem::size_of::<m128d>(), 16);
   assert_eq!(core::mem::align_of::<m128d>(), 16);
 }

--- a/src/intel/m128i_.rs
+++ b/src/intel/m128i_.rs
@@ -26,7 +26,7 @@ unsafe impl bytemuck::Pod for m128i {}
 unsafe impl bytemuck::TransparentWrapper<__m128i> for m128i {}
 
 #[test]
-fn test_m128_size_align() {
+fn test_m128i_size_align() {
   assert_eq!(core::mem::size_of::<m128i>(), 16);
   assert_eq!(core::mem::align_of::<m128i>(), 16);
 }

--- a/src/intel/m256_.rs
+++ b/src/intel/m256_.rs
@@ -1,4 +1,4 @@
-//! This module is for the `m128` wrapper type, its bonus methods, and all
+//! This module is for the `m256` wrapper type, its bonus methods, and all
 //! necessary trait impls.
 //!
 //! Intrinsics should _not_ be in this module! They should all be free-functions
@@ -6,90 +6,88 @@
 
 use super::*;
 
-/// The data for a 128-bit SSE register of four `f32` lanes.
+/// The data for a 256-bit SSE register of eight `f32` lanes.
 ///
-/// * This is _very similar to_ having `[f32; 4]`. The main difference is that
-///   it's aligned to 16 instead of just 4, and of course you can perform
+/// * This is _very similar to_ having `[f32; 8]`. The main difference is that
+///   it's aligned to 32 instead of just 4, and of course you can perform
 ///   various intrinsic operations on it.
 #[repr(transparent)]
 #[allow(non_camel_case_types)]
-pub struct m128(pub __m128);
+pub struct m256(pub __m256);
 
 #[cfg(feature = "bytemuck")]
-unsafe impl bytemuck::Zeroable for m128 {}
+unsafe impl bytemuck::Zeroable for m256 {}
 #[cfg(feature = "bytemuck")]
-unsafe impl bytemuck::Pod for m128 {}
+unsafe impl bytemuck::Pod for m256 {}
 #[cfg(feature = "bytemuck")]
-unsafe impl bytemuck::TransparentWrapper<__m128> for m128 {}
+unsafe impl bytemuck::TransparentWrapper<__m256> for m256 {}
 
 #[test]
-fn test_m128_size_align() {
-  assert_eq!(core::mem::size_of::<m128>(), 16);
-  assert_eq!(core::mem::align_of::<m128>(), 16);
+fn test_m256_size_align() {
+  assert_eq!(core::mem::size_of::<m256>(), 32);
+  assert_eq!(core::mem::align_of::<m256>(), 32);
 }
 
-impl m128 {
-  /// Transmutes the `m128` to an array.
+impl m256 {
+  /// Transmutes the `m256` to an array.
   ///
   /// Same as `m.into()`, just lets you be more explicit about what's happening.
   #[must_use]
   #[inline(always)]
-  pub fn to_array(self) -> [f32; 4] {
+  pub fn to_array(self) -> [f32; 8] {
     self.into()
   }
 
-  /// Transmutes an array into `m128`.
+  /// Transmutes an array into `m256`.
   ///
-  /// Same as `m128::from(arr)`, it just lets you be more explicit about what's
+  /// Same as `m256::from(arr)`, it just lets you be more explicit about what's
   /// happening.
   #[must_use]
   #[inline(always)]
-  pub fn from_array(f: [f32; 4]) -> Self {
+  pub fn from_array(f: [f32; 8]) -> Self {
     f.into()
   }
 
-  //
-
-  /// Converts into the bit patterns of these floats (`[u32;4]`).
+  /// Converts into the bit patterns of these floats (`[u32;8]`).
   ///
-  /// Like [`f32::to_bits`](f32::to_bits), but all four lanes at once.
+  /// Like [`f32::to_bits`](f32::to_bits), but all eight lanes at once.
   #[must_use]
   #[inline(always)]
-  pub fn to_bits(self) -> [u32; 4] {
+  pub fn to_bits(self) -> [u32; 8] {
     unsafe { core::mem::transmute(self) }
   }
 
-  /// Converts from the bit patterns of these floats (`[u32;4]`).
+  /// Converts from the bit patterns of these floats (`[u32;8]`).
   ///
-  /// Like [`f32::from_bits`](f32::from_bits), but all four lanes at once.
+  /// Like [`f32::from_bits`](f32::from_bits), but all eight lanes at once.
   #[must_use]
   #[inline(always)]
-  pub fn from_bits(bits: [u32; 4]) -> Self {
+  pub fn from_bits(bits: [u32; 8]) -> Self {
     unsafe { core::mem::transmute(bits) }
   }
 }
 
-impl Clone for m128 {
+impl Clone for m256 {
   #[must_use]
   #[inline(always)]
   fn clone(&self) -> Self {
     *self
   }
 }
-impl Copy for m128 {}
+impl Copy for m256 {}
 
-impl Default for m128 {
+impl Default for m256 {
   #[must_use]
   #[inline(always)]
   fn default() -> Self {
-    zeroed_m128()
+    unsafe { core::mem::zeroed() }
   }
 }
 
-impl From<[f32; 4]> for m128 {
+impl From<[f32; 8]> for m256 {
   #[must_use]
   #[inline(always)]
-  fn from(arr: [f32; 4]) -> Self {
+  fn from(arr: [f32; 8]) -> Self {
     // Safety: because this semantically moves the value from the input position
     // (align4) to the output position (align16) it is fine to increase our
     // required alignment without worry.
@@ -97,10 +95,10 @@ impl From<[f32; 4]> for m128 {
   }
 }
 
-impl From<m128> for [f32; 4] {
+impl From<m256> for [f32; 8] {
   #[must_use]
   #[inline(always)]
-  fn from(m: m128) -> Self {
+  fn from(m: m256) -> Self {
     // We can of course transmute to a lower alignment
     unsafe { core::mem::transmute(m) }
   }
@@ -110,15 +108,15 @@ impl From<m128> for [f32; 4] {
 // PLEASE KEEP ALL THE FORMAT IMPL JUNK AT THE END OF THE FILE
 //
 
-impl Debug for m128 {
+impl Debug for m256 {
   /// Debug formats each float.
   /// ```
   /// # use safe_arch::*;
-  /// let f = format!("{:?}", m128::default());
-  /// assert_eq!(&f, "m128(0.0, 0.0, 0.0, 0.0)");
+  /// let f = format!("{:?}", m256::default());
+  /// assert_eq!(&f, "m256(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)");
   /// ```
   fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-    write!(f, "m128(")?;
+    write!(f, "m256(")?;
     for (i, float) in self.to_array().iter().enumerate() {
       if i != 0 {
         write!(f, ", ")?;
@@ -129,12 +127,12 @@ impl Debug for m128 {
   }
 }
 
-impl Display for m128 {
+impl Display for m256 {
   /// Display formats each float, and leaves the type name off of the font.
   /// ```
   /// # use safe_arch::*;
-  /// let f = format!("{}", m128::default());
-  /// assert_eq!(&f, "(0, 0, 0, 0)");
+  /// let f = format!("{}", m256::default());
+  /// assert_eq!(&f, "(0, 0, 0, 0, 0, 0, 0, 0)");
   /// ```
   fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
     write!(f, "(")?;
@@ -148,12 +146,12 @@ impl Display for m128 {
   }
 }
 
-impl Binary for m128 {
+impl Binary for m256 {
   /// Binary formats each float's bit pattern (via [`f32::to_bits`]).
   /// ```
   /// # use safe_arch::*;
-  /// let f = format!("{:b}", m128::default());
-  /// assert_eq!(&f, "(0, 0, 0, 0)");
+  /// let f = format!("{:b}", m256::default());
+  /// assert_eq!(&f, "(0, 0, 0, 0, 0, 0, 0, 0)");
   /// ```
   fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
     write!(f, "(")?;
@@ -167,12 +165,12 @@ impl Binary for m128 {
   }
 }
 
-impl LowerExp for m128 {
+impl LowerExp for m256 {
   /// LowerExp formats each float.
   /// ```
   /// # use safe_arch::*;
-  /// let f = format!("{:e}", m128::default());
-  /// assert_eq!(&f, "(0e0, 0e0, 0e0, 0e0)");
+  /// let f = format!("{:e}", m256::default());
+  /// assert_eq!(&f, "(0e0, 0e0, 0e0, 0e0, 0e0, 0e0, 0e0, 0e0)");
   /// ```
   fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
     write!(f, "(")?;
@@ -186,12 +184,12 @@ impl LowerExp for m128 {
   }
 }
 
-impl UpperExp for m128 {
+impl UpperExp for m256 {
   /// UpperExp formats each float.
   /// ```
   /// # use safe_arch::*;
-  /// let f = format!("{:E}", m128::default());
-  /// assert_eq!(&f, "(0E0, 0E0, 0E0, 0E0)");
+  /// let f = format!("{:E}", m256::default());
+  /// assert_eq!(&f, "(0E0, 0E0, 0E0, 0E0, 0E0, 0E0, 0E0, 0E0)");
   /// ```
   fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
     write!(f, "(")?;
@@ -205,12 +203,12 @@ impl UpperExp for m128 {
   }
 }
 
-impl LowerHex for m128 {
+impl LowerHex for m256 {
   /// LowerHex formats each float's bit pattern (via [`f32::to_bits`]).
   /// ```
   /// # use safe_arch::*;
-  /// let f = format!("{:x}", m128::default());
-  /// assert_eq!(&f, "(0, 0, 0, 0)");
+  /// let f = format!("{:x}", m256::default());
+  /// assert_eq!(&f, "(0, 0, 0, 0, 0, 0, 0, 0)");
   /// ```
   fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
     write!(f, "(")?;
@@ -224,12 +222,12 @@ impl LowerHex for m128 {
   }
 }
 
-impl UpperHex for m128 {
+impl UpperHex for m256 {
   /// UpperHex formats each float's bit pattern (via [`f32::to_bits`]).
   /// ```
   /// # use safe_arch::*;
-  /// let f = format!("{:X}", m128::default());
-  /// assert_eq!(&f, "(0, 0, 0, 0)");
+  /// let f = format!("{:X}", m256::default());
+  /// assert_eq!(&f, "(0, 0, 0, 0, 0, 0, 0, 0)");
   /// ```
   fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
     write!(f, "(")?;
@@ -243,12 +241,12 @@ impl UpperHex for m128 {
   }
 }
 
-impl Octal for m128 {
+impl Octal for m256 {
   /// Octal formats each float's bit pattern (via [`f32::to_bits`]).
   /// ```
   /// # use safe_arch::*;
-  /// let f = format!("{:o}", m128::default());
-  /// assert_eq!(&f, "(0, 0, 0, 0)");
+  /// let f = format!("{:o}", m256::default());
+  /// assert_eq!(&f, "(0, 0, 0, 0, 0, 0, 0, 0)");
   /// ```
   fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
     write!(f, "(")?;

--- a/src/intel/m256d_.rs
+++ b/src/intel/m256d_.rs
@@ -1,4 +1,4 @@
-//! This module is for the `m128d` wrapper type, its bonus methods, and all
+//! This module is for the `m256d` wrapper type, its bonus methods, and all
 //! necessary trait impls.
 //!
 //! Intrinsics should _not_ be in this module! They should all be free-functions
@@ -6,110 +6,90 @@
 
 use super::*;
 
-/// The data for a 128-bit SSE register of two `f64` values.
+/// The data for a 256-bit SSE register of four `f64` values.
 ///
-/// * This is _very similar to_ having `[f64; 2]`. The main difference is that
-///   it's aligned to 16 instead of just 4, and of course you can perform
+/// * This is _very similar to_ having `[f64; 4]`. The main difference is that
+///   it's aligned to 32 instead of just 4, and of course you can perform
 ///   various intrinsic operations on it.
 #[repr(transparent)]
 #[allow(non_camel_case_types)]
-pub struct m128d(pub __m128d);
+pub struct m256d(pub __m256d);
 
 #[cfg(feature = "bytemuck")]
-unsafe impl bytemuck::Zeroable for m128d {}
+unsafe impl bytemuck::Zeroable for m256d {}
 #[cfg(feature = "bytemuck")]
-unsafe impl bytemuck::Pod for m128d {}
+unsafe impl bytemuck::Pod for m256d {}
 #[cfg(feature = "bytemuck")]
-unsafe impl bytemuck::TransparentWrapper<__m128d> for m128d {}
+unsafe impl bytemuck::TransparentWrapper<__m256d> for m256d {}
 
 #[test]
-fn test_m128_size_align() {
-  assert_eq!(core::mem::size_of::<m128d>(), 16);
-  assert_eq!(core::mem::align_of::<m128d>(), 16);
+fn test_m256_size_align() {
+  assert_eq!(core::mem::size_of::<m256d>(), 32);
+  assert_eq!(core::mem::align_of::<m256d>(), 32);
 }
 
-impl m128d {
-  /// Transmutes the `m128d` to an array.
+impl m256d {
+  /// Transmutes the `m256d` to an array.
   ///
   /// Same as `m.into()`, just lets you be more explicit about what's happening.
   #[must_use]
   #[inline(always)]
-  pub fn to_array(self) -> [f64; 2] {
+  pub fn to_array(self) -> [f64; 4] {
     self.into()
   }
 
-  /// Transmutes an array into `m128d`.
+  /// Transmutes an array into `m256d`.
   ///
-  /// Same as `m128d::from(arr)`, it just lets you be more explicit about what's
+  /// Same as `m256d::from(arr)`, it just lets you be more explicit about what's
   /// happening.
   #[must_use]
   #[inline(always)]
-  pub fn from_array(f: [f64; 2]) -> Self {
+  pub fn from_array(f: [f64; 4]) -> Self {
     f.into()
   }
 
   //
 
-  /// Converts into the bit patterns of these doubles (`[u64;2]`).
+  /// Converts into the bit patterns of these doubles (`[u64;4]`).
   ///
   /// Like [`f64::to_bits`](f64::to_bits), but both lanes at once.
   #[must_use]
   #[inline(always)]
-  pub fn to_bits(self) -> [u64; 2] {
+  pub fn to_bits(self) -> [u64; 4] {
     unsafe { core::mem::transmute(self) }
   }
 
-  /// Converts from the bit patterns of these doubles (`[u64;2]`).
+  /// Converts from the bit patterns of these doubles (`[u64;4]`).
   ///
   /// Like [`f64::from_bits`](f64::from_bits), but both lanes at once.
   #[must_use]
   #[inline(always)]
-  pub fn from_bits(bits: [u64; 2]) -> Self {
+  pub fn from_bits(bits: [u64; 4]) -> Self {
     unsafe { core::mem::transmute(bits) }
   }
 }
 
-impl AsRef<[f64; 2]> for m128d {
-  #[must_use]
-  #[inline(always)]
-  fn as_ref(&self) -> &[f64; 2] {
-    // Safety: Since the alignment requirement of the output reference type is
-    // lower than our own reference type this is safe.
-    unsafe { core::mem::transmute(self) }
-  }
-}
-
-impl AsMut<[f64; 2]> for m128d {
-  #[must_use]
-  #[inline(always)]
-  fn as_mut(&mut self) -> &mut [f64; 2] {
-    // Safety: Since the alignment requirement of the output reference type is
-    // lower than our own reference type this is safe.
-    unsafe { core::mem::transmute(self) }
-  }
-}
-
-impl Clone for m128d {
+impl Clone for m256d {
   #[must_use]
   #[inline(always)]
   fn clone(&self) -> Self {
     *self
   }
 }
-impl Copy for m128d {}
+impl Copy for m256d {}
 
-impl Default for m128d {
+impl Default for m256d {
   #[must_use]
   #[inline(always)]
   fn default() -> Self {
-    zeroed_m128d()
+    unsafe { core::mem::zeroed() }
   }
 }
 
-impl From<[f64; 2]> for m128d {
+impl From<[f64; 4]> for m256d {
   #[must_use]
   #[inline(always)]
-  fn from(arr: [f64; 2]) -> Self {
+  fn from(arr: [f64; 4]) -> Self {
     // Safety: because this semantically moves the value from the input position
     // (align8) to the output position (align16) it is fine to increase our
     // required alignment without worry.
@@ -117,10 +97,10 @@ impl From<[f64; 2]> for m128d {
   }
 }
 
-impl From<m128d> for [f64; 2] {
+impl From<m256d> for [f64; 4] {
   #[must_use]
   #[inline(always)]
-  fn from(m: m128d) -> Self {
+  fn from(m: m256d) -> Self {
     // We can of course transmute to a lower alignment
     unsafe { core::mem::transmute(m) }
   }
@@ -130,16 +110,16 @@ impl From<m128d> for [f64; 2] {
 // PLEASE KEEP ALL THE FORMAT IMPL JUNK AT THE END OF THE FILE
 //
 
-impl Debug for m128d {
+impl Debug for m256d {
   /// Debug formats each double.
   /// ```
   /// # use safe_arch::*;
-  /// let f = format!("{:?}", m128d::default());
-  /// assert_eq!(&f, "m128d(0.0, 0.0)");
+  /// let f = format!("{:?}", m256d::default());
+  /// assert_eq!(&f, "m256d(0.0, 0.0)");
   /// ```
   fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
     let a = self.to_array();
-    write!(f, "m128d(")?;
+    write!(f, "m256d(")?;
     Debug::fmt(&a[0], f)?;
     write!(f, ", ")?;
     Debug::fmt(&a[1], f)?;
@@ -147,11 +127,11 @@ impl Debug for m128d {
   }
 }
 
-impl Display for m128d {
+impl Display for m256d {
   /// Display formats each double, and leaves the type name off of the font.
   /// ```
   /// # use safe_arch::*;
-  /// let f = format!("{}", m128d::default());
+  /// let f = format!("{}", m256d::default());
   /// assert_eq!(&f, "(0, 0)");
   /// ```
   fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
@@ -164,11 +144,11 @@ impl Display for m128d {
   }
 }
 
-impl Binary for m128d {
+impl Binary for m256d {
   /// Binary formats each double's bit pattern (via [`f64::to_bits`]).
   /// ```
   /// # use safe_arch::*;
-  /// let f = format!("{:b}", m128d::default());
+  /// let f = format!("{:b}", m256d::default());
   /// assert_eq!(&f, "(0, 0)");
   /// ```
   fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
@@ -181,11 +161,11 @@ impl Binary for m128d {
   }
 }
 
-impl LowerExp for m128d {
+impl LowerExp for m256d {
   /// LowerExp formats each double.
   /// ```
   /// # use safe_arch::*;
-  /// let f = format!("{:e}", m128d::default());
+  /// let f = format!("{:e}", m256d::default());
   /// assert_eq!(&f, "(0e0, 0e0)");
   /// ```
   fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
@@ -198,11 +178,11 @@ impl LowerExp for m128d {
   }
 }
 
-impl UpperExp for m128d {
+impl UpperExp for m256d {
   /// UpperExp formats each double.
   /// ```
   /// # use safe_arch::*;
-  /// let f = format!("{:E}", m128d::default());
+  /// let f = format!("{:E}", m256d::default());
   /// assert_eq!(&f, "(0E0, 0E0)");
   /// ```
   fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
@@ -215,11 +195,11 @@ impl UpperExp for m128d {
   }
 }
 
-impl LowerHex for m128d {
+impl LowerHex for m256d {
   /// LowerHex formats each double's bit pattern (via [`f64::to_bits`]).
   /// ```
   /// # use safe_arch::*;
-  /// let f = format!("{:x}", m128d::default());
+  /// let f = format!("{:x}", m256d::default());
   /// assert_eq!(&f, "(0, 0)");
   /// ```
   fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
@@ -232,11 +212,11 @@ impl LowerHex for m128d {
   }
 }
 
-impl UpperHex for m128d {
+impl UpperHex for m256d {
   /// UpperHex formats each double's bit pattern (via [`f64::to_bits`]).
   /// ```
   /// # use safe_arch::*;
-  /// let f = format!("{:X}", m128d::default());
+  /// let f = format!("{:X}", m256d::default());
   /// assert_eq!(&f, "(0, 0)");
   /// ```
   fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
@@ -249,11 +229,11 @@ impl UpperHex for m128d {
   }
 }
 
-impl Octal for m128d {
+impl Octal for m256d {
   /// Octal formats each double's bit pattern (via [`f64::to_bits`]).
   /// ```
   /// # use safe_arch::*;
-  /// let f = format!("{:o}", m128d::default());
+  /// let f = format!("{:o}", m256d::default());
   /// assert_eq!(&f, "(0, 0)");
   /// ```
   fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {

--- a/src/intel/m256d_.rs
+++ b/src/intel/m256d_.rs
@@ -23,7 +23,7 @@ unsafe impl bytemuck::Pod for m256d {}
 unsafe impl bytemuck::TransparentWrapper<__m256d> for m256d {}
 
 #[test]
-fn test_m256_size_align() {
+fn test_m256d_size_align() {
   assert_eq!(core::mem::size_of::<m256d>(), 32);
   assert_eq!(core::mem::align_of::<m256d>(), 32);
 }

--- a/src/intel/m256i_.rs
+++ b/src/intel/m256i_.rs
@@ -26,7 +26,7 @@ unsafe impl bytemuck::Pod for m256i {}
 unsafe impl bytemuck::TransparentWrapper<__m256i> for m256i {}
 
 #[test]
-fn test_m256_size_align() {
+fn test_m256i_size_align() {
   assert_eq!(core::mem::size_of::<m256i>(), 32);
   assert_eq!(core::mem::align_of::<m256i>(), 32);
 }

--- a/src/intel/m256i_.rs
+++ b/src/intel/m256i_.rs
@@ -1,0 +1,375 @@
+//! This module is for the `m256i` wrapper type, its bonus methods, and all
+//! necessary trait impls.
+//!
+//! Intrinsics should _not_ be in this module! They should all be free-functions
+//! in the other modules, sorted by CPU target feature.
+
+use super::*;
+
+/// The data for a 256-bit SSE register of integer data.
+///
+/// * The exact layout to view the type as depends on the operation used.
+/// * `From` and `Into` impls are provided for all the relevant signed integer
+///   array types.
+/// * Formatting impls print as four `i32` values just because they have to pick
+///   something. If you want an alternative you can turn it into an array and
+///   print as you like.
+#[repr(transparent)]
+#[allow(non_camel_case_types)]
+pub struct m256i(pub __m256i);
+
+#[cfg(feature = "bytemuck")]
+unsafe impl bytemuck::Zeroable for m256i {}
+#[cfg(feature = "bytemuck")]
+unsafe impl bytemuck::Pod for m256i {}
+#[cfg(feature = "bytemuck")]
+unsafe impl bytemuck::TransparentWrapper<__m256i> for m256i {}
+
+#[test]
+fn test_m256_size_align() {
+  assert_eq!(core::mem::size_of::<m256i>(), 32);
+  assert_eq!(core::mem::align_of::<m256i>(), 32);
+}
+
+impl Clone for m256i {
+  #[must_use]
+  #[inline(always)]
+  fn clone(&self) -> Self {
+    *self
+  }
+}
+impl Copy for m256i {}
+
+impl Default for m256i {
+  #[must_use]
+  #[inline(always)]
+  fn default() -> Self {
+    unsafe { core::mem::zeroed() }
+  }
+}
+
+// 8-bit
+
+impl From<[i8; 32]> for m256i {
+  #[must_use]
+  #[inline(always)]
+  fn from(arr: [i8; 32]) -> Self {
+    unsafe { core::mem::transmute(arr) }
+  }
+}
+
+impl From<m256i> for [i8; 32] {
+  #[must_use]
+  #[inline(always)]
+  fn from(m: m256i) -> Self {
+    unsafe { core::mem::transmute(m) }
+  }
+}
+
+impl From<[u8; 32]> for m256i {
+  #[must_use]
+  #[inline(always)]
+  fn from(arr: [u8; 32]) -> Self {
+    unsafe { core::mem::transmute(arr) }
+  }
+}
+
+impl From<m256i> for [u8; 32] {
+  #[must_use]
+  #[inline(always)]
+  fn from(m: m256i) -> Self {
+    unsafe { core::mem::transmute(m) }
+  }
+}
+
+// 16-bit
+
+impl From<[i16; 16]> for m256i {
+  #[must_use]
+  #[inline(always)]
+  fn from(arr: [i16; 16]) -> Self {
+    unsafe { core::mem::transmute(arr) }
+  }
+}
+
+impl From<m256i> for [i16; 16] {
+  #[must_use]
+  #[inline(always)]
+  fn from(m: m256i) -> Self {
+    unsafe { core::mem::transmute(m) }
+  }
+}
+
+impl From<[u16; 16]> for m256i {
+  #[must_use]
+  #[inline(always)]
+  fn from(arr: [u16; 16]) -> Self {
+    unsafe { core::mem::transmute(arr) }
+  }
+}
+
+impl From<m256i> for [u16; 16] {
+  #[must_use]
+  #[inline(always)]
+  fn from(m: m256i) -> Self {
+    unsafe { core::mem::transmute(m) }
+  }
+}
+
+// 32-bit
+
+impl From<[i32; 8]> for m256i {
+  #[must_use]
+  #[inline(always)]
+  fn from(arr: [i32; 8]) -> Self {
+    unsafe { core::mem::transmute(arr) }
+  }
+}
+
+impl From<m256i> for [i32; 8] {
+  #[must_use]
+  #[inline(always)]
+  fn from(m: m256i) -> Self {
+    unsafe { core::mem::transmute(m) }
+  }
+}
+
+impl From<[u32; 8]> for m256i {
+  #[must_use]
+  #[inline(always)]
+  fn from(arr: [u32; 8]) -> Self {
+    unsafe { core::mem::transmute(arr) }
+  }
+}
+
+impl From<m256i> for [u32; 8] {
+  #[must_use]
+  #[inline(always)]
+  fn from(m: m256i) -> Self {
+    unsafe { core::mem::transmute(m) }
+  }
+}
+
+// 64-bit
+
+impl From<[i64; 4]> for m256i {
+  #[must_use]
+  #[inline(always)]
+  fn from(arr: [i64; 4]) -> Self {
+    unsafe { core::mem::transmute(arr) }
+  }
+}
+
+impl From<m256i> for [i64; 4] {
+  #[must_use]
+  #[inline(always)]
+  fn from(m: m256i) -> Self {
+    unsafe { core::mem::transmute(m) }
+  }
+}
+
+impl From<[u64; 4]> for m256i {
+  #[must_use]
+  #[inline(always)]
+  fn from(arr: [u64; 4]) -> Self {
+    unsafe { core::mem::transmute(arr) }
+  }
+}
+
+impl From<m256i> for [u64; 4] {
+  #[must_use]
+  #[inline(always)]
+  fn from(m: m256i) -> Self {
+    unsafe { core::mem::transmute(m) }
+  }
+}
+
+// 256-bit
+
+impl From<[i128; 2]> for m256i {
+  #[must_use]
+  #[inline(always)]
+  fn from(i: [i128; 2]) -> Self {
+    unsafe { core::mem::transmute(i) }
+  }
+}
+
+impl From<m256i> for [i128; 2] {
+  #[must_use]
+  #[inline(always)]
+  fn from(m: m256i) -> Self {
+    unsafe { core::mem::transmute(m) }
+  }
+}
+
+impl From<[u128; 2]> for m256i {
+  #[must_use]
+  #[inline(always)]
+  fn from(u: [u128; 2]) -> Self {
+    unsafe { core::mem::transmute(u) }
+  }
+}
+
+impl From<m256i> for [u128; 2] {
+  #[must_use]
+  #[inline(always)]
+  fn from(m: m256i) -> Self {
+    unsafe { core::mem::transmute(m) }
+  }
+}
+
+//
+// PLEASE KEEP ALL THE FORMAT IMPL JUNK AT THE END OF THE FILE
+//
+
+impl Debug for m256i {
+  /// Debug formats each `i32`.
+  /// ```
+  /// # use safe_arch::*;
+  /// let f = format!("{:?}", m256i::default());
+  /// assert_eq!(&f, "m256i(0, 0, 0, 0, 0, 0, 0, 0)");
+  /// ```
+  fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+    write!(f, "m256i(")?;
+    for (i, int) in <[i32; 8]>::from(*self).iter().enumerate() {
+      if i != 0 {
+        write!(f, ", ")?;
+      }
+      Debug::fmt(int, f)?;
+    }
+    write!(f, ")")
+  }
+}
+
+impl Display for m256i {
+  /// Display formats each `i32`, and leaves the type name off of the font.
+  /// ```
+  /// # use safe_arch::*;
+  /// let f = format!("{}", m256i::default());
+  /// assert_eq!(&f, "(0, 0, 0, 0, 0, 0, 0, 0)");
+  /// ```
+  fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+    write!(f, "(")?;
+    for (i, int) in <[i32; 8]>::from(*self).iter().enumerate() {
+      if i != 0 {
+        write!(f, ", ")?;
+      }
+      Display::fmt(int, f)?;
+    }
+    write!(f, ")")
+  }
+}
+
+impl Binary for m256i {
+  /// Binary formats each `i32`.
+  /// ```
+  /// # use safe_arch::*;
+  /// let f = format!("{:b}", m256i::default());
+  /// assert_eq!(&f, "(0, 0, 0, 0, 0, 0, 0, 0)");
+  /// ```
+  fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+    write!(f, "(")?;
+    for (i, int) in <[i32; 8]>::from(*self).iter().enumerate() {
+      if i != 0 {
+        write!(f, ", ")?;
+      }
+      Binary::fmt(int, f)?;
+    }
+    write!(f, ")")
+  }
+}
+
+impl LowerExp for m256i {
+  /// LowerExp formats each `i32`.
+  /// ```
+  /// # use safe_arch::*;
+  /// let f = format!("{:e}", m256i::default());
+  /// assert_eq!(&f, "(0e0, 0e0, 0e0, 0e0, 0e0, 0e0, 0e0, 0e0)");
+  /// ```
+  fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+    write!(f, "(")?;
+    for (i, int) in <[i32; 8]>::from(*self).iter().enumerate() {
+      if i != 0 {
+        write!(f, ", ")?;
+      }
+      LowerExp::fmt(int, f)?;
+    }
+    write!(f, ")")
+  }
+}
+
+impl UpperExp for m256i {
+  /// UpperExp formats each `i32`.
+  /// ```
+  /// # use safe_arch::*;
+  /// let f = format!("{:E}", m256i::default());
+  /// assert_eq!(&f, "(0E0, 0E0, 0E0, 0E0, 0E0, 0E0, 0E0, 0E0)");
+  /// ```
+  fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+    write!(f, "(")?;
+    for (i, int) in <[i32; 8]>::from(*self).iter().enumerate() {
+      if i != 0 {
+        write!(f, ", ")?;
+      }
+      UpperExp::fmt(int, f)?;
+    }
+    write!(f, ")")
+  }
+}
+
+impl LowerHex for m256i {
+  /// LowerHex formats each `i32`.
+  /// ```
+  /// # use safe_arch::*;
+  /// let f = format!("{:x}", m256i::default());
+  /// assert_eq!(&f, "(0, 0, 0, 0, 0, 0, 0, 0)");
+  /// ```
+  fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+    write!(f, "(")?;
+    for (i, int) in <[i32; 8]>::from(*self).iter().enumerate() {
+      if i != 0 {
+        write!(f, ", ")?;
+      }
+      LowerHex::fmt(int, f)?;
+    }
+    write!(f, ")")
+  }
+}
+
+impl UpperHex for m256i {
+  /// UpperHex formats each `i32`.
+  /// ```
+  /// # use safe_arch::*;
+  /// let f = format!("{:X}", m256i::default());
+  /// assert_eq!(&f, "(0, 0, 0, 0, 0, 0, 0, 0)");
+  /// ```
+  fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+    write!(f, "(")?;
+    for (i, int) in <[i32; 8]>::from(*self).iter().enumerate() {
+      if i != 0 {
+        write!(f, ", ")?;
+      }
+      UpperHex::fmt(int, f)?;
+    }
+    write!(f, ")")
+  }
+}
+
+impl Octal for m256i {
+  /// Octal formats each `i32`.
+  /// ```
+  /// # use safe_arch::*;
+  /// let f = format!("{:o}", m256i::default());
+  /// assert_eq!(&f, "(0, 0, 0, 0, 0, 0, 0, 0)");
+  /// ```
+  fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+    write!(f, "(")?;
+    for (i, int) in <[i32; 8]>::from(*self).iter().enumerate() {
+      if i != 0 {
+        write!(f, ", ")?;
+      }
+      Octal::fmt(int, f)?;
+    }
+    write!(f, ")")
+  }
+}

--- a/src/intel/sse.rs
+++ b/src/intel/sse.rs
@@ -638,21 +638,21 @@ pub fn load_m128(a: &m128) -> m128 {
   m128(unsafe { _mm_load_ps(a as *const m128 as *const f32) })
 }
 
-/// Loads the reference into all lanes of a register.
+/// Loads the `f32` reference into all lanes of a register.
 /// ```
 /// # use safe_arch::*;
 /// let a = 1.0;
-/// let b = load_splat_m128(&a);
+/// let b = load_f32_splat_m128(&a);
 /// assert_eq!(m128::from_array([1.0, 1.0, 1.0, 1.0]).to_bits(), b.to_bits());
 /// ```
 #[must_use]
 #[inline(always)]
 #[allow(clippy::trivially_copy_pass_by_ref)]
-pub fn load_splat_m128(a: &f32) -> m128 {
+pub fn load_f32_splat_m128(a: &f32) -> m128 {
   m128(unsafe { _mm_load_ps1(a) })
 }
 
-/// Loads the reference into the low lane of the register.
+/// Loads the `f32` reference into the low lane of the register.
 /// ```
 /// # use safe_arch::*;
 /// let a = 1.0;

--- a/src/intel/sse.rs
+++ b/src/intel/sse.rs
@@ -649,6 +649,7 @@ pub fn load_m128(a: &m128) -> m128 {
 #[inline(always)]
 #[allow(clippy::trivially_copy_pass_by_ref)]
 pub fn load_f32_splat_m128(a: &f32) -> m128 {
+  // question: how is this different from _mm_broadcast_ss?
   m128(unsafe { _mm_load_ps1(a) })
 }
 

--- a/src/intel/sse.rs
+++ b/src/intel/sse.rs
@@ -985,8 +985,6 @@ pub fn zeroed_m128() -> m128 {
 /// This is a macro because the shuffle pattern must be a compile time constant,
 /// and Rust doesn't currently support that for functions.
 ///
-/// ## Two `m128` Inputs
-/// You can provide two `m128` arguments, in which case:
 /// * The low lanes of the output come from `$a`, as picked by `$z` and `$o`
 ///   (Zero and One)
 /// * The high lanes of the output come from `$b`, as picked by `$t` and `$e`
@@ -1014,25 +1012,6 @@ pub fn zeroed_m128() -> m128 {
 /// let c = shuffle_m128!(a, b, 0, 2, 2, 1).to_array();
 /// assert_eq!(c, [1.0, 3.0, 7.0, 6.0]);
 /// ```
-///
-/// ## One `m128` Input
-/// You can provide one `m128` argument, in which case the above variant is
-/// called with `$a` as the input to both sides of the shuffle (note that any
-/// potential side effects of evaluating `$a` are executed only once).
-///
-/// ```
-/// # use safe_arch::*;
-/// let a = m128::from_array([1.0, 2.0, 3.0, 4.0]);
-/// //
-/// let c = shuffle_m128!(a, 0, 0, 0, 0).to_array();
-/// assert_eq!(c, [1.0, 1.0, 1.0, 1.0]);
-/// //
-/// let c = shuffle_m128!(a, 0, 1, 2, 3).to_array();
-/// assert_eq!(c, [1.0, 2.0, 3.0, 4.0]);
-/// //
-/// let c = shuffle_m128!(a, 0, 2, 2, 1).to_array();
-/// assert_eq!(c, [1.0, 3.0, 3.0, 2.0]);
-/// ```
 #[cfg_attr(target_feature = "sse", macro_export)]
 macro_rules! shuffle_m128 {
   ($a:expr, $b:expr, $z:expr, $o:expr, $t:expr, $e:expr) => {{
@@ -1046,13 +1025,6 @@ macro_rules! shuffle_m128 {
     #[cfg(target_arch = "x86_64")]
     use ::core::arch::x86_64::_mm_shuffle_ps;
     m128(unsafe { _mm_shuffle_ps(a.0, b.0, MASK) })
-  }};
-  ($a:expr, $z:expr, $o:expr, $t:expr, $e:expr) => {{
-    // Note(Lokathor): this makes sure that any side-effecting expressions we
-    // get as input are only executed once, then that expression output goes
-    // into both sides of the shuffle.
-    let a: m128 = $a;
-    shuffle_m128!(a, a, $z, $o, $t, $e)
   }};
 }
 

--- a/src/intel/sse2.rs
+++ b/src/intel/sse2.rs
@@ -2244,8 +2244,6 @@ macro_rules! shuffle_i32_m128i {
 /// This is a macro because the shuffle pattern must be a compile time constant,
 /// and Rust doesn't currently support that for functions.
 ///
-/// ## Two `m128d` Inputs
-/// You can provide two `m128d` arguments, in which case:
 /// * The lane lane of the output comes from `$a`, as picked by `$z` (Zero)
 /// * The high lane of the output comes from `$b`, as picked by `$o` (One)
 /// * `$a` and `$b` must obviously be `m128d` expressions.
@@ -2268,22 +2266,6 @@ macro_rules! shuffle_i32_m128i {
 /// let c = shuffle_m128d!(a, b, 0, 1).to_array();
 /// assert_eq!(c, [1.0, 4.0]);
 /// ```
-///
-/// ## One `m128` Input
-/// You can provide one `m128d` argument, in which case the above variant is
-/// called with `$a` as the input to both sides of the shuffle (note that any
-/// potential side effects of evaluating `$a` are executed only once).
-///
-/// ```
-/// # use safe_arch::*;
-/// let a = m128d::from_array([1.0, 2.0]);
-/// //
-/// let c = shuffle_m128d!(a, 0, 0).to_array();
-/// assert_eq!(c, [1.0, 1.0]);
-/// //
-/// let c = shuffle_m128d!(a, 0, 1).to_array();
-/// assert_eq!(c, [1.0, 2.0]);
-/// ```
 #[macro_export]
 macro_rules! shuffle_m128d {
   ($a:expr, $b:expr, $z:expr, $o:expr) => {{
@@ -2295,13 +2277,6 @@ macro_rules! shuffle_m128d {
     #[cfg(target_arch = "x86_64")]
     use ::core::arch::x86_64::_mm_shuffle_pd;
     m128d(unsafe { _mm_shuffle_pd(a.0, b.0, MASK) })
-  }};
-  ($a:expr, $z:expr, $o:expr) => {{
-    // Note(Lokathor): this makes sure that any side-effecting expressions we
-    // get as input are only executed once, then that expression output goes
-    // into both sides of the shuffle.
-    let a: m128d = $a;
-    shuffle_m128d!(a, a, $z, $o)
   }};
 }
 

--- a/src/intel/sse2.rs
+++ b/src/intel/sse2.rs
@@ -1407,17 +1407,17 @@ pub fn load_m128d(a: &m128d) -> m128d {
   m128d(unsafe { _mm_load_pd(a as *const m128d as *const f64) })
 }
 
-/// Loads the reference into all lanes of a register.
+/// Loads the `f64` reference into all lanes of a register.
 /// ```
 /// # use safe_arch::*;
 /// let a = 1.0;
-/// let b = load_splat_m128d(&a);
+/// let b = load_f64_splat_m128d(&a);
 /// assert_eq!(m128d::from_array([1.0, 1.0]).to_bits(), b.to_bits());
 /// ```
 #[must_use]
 #[inline(always)]
 #[allow(clippy::trivially_copy_pass_by_ref)]
-pub fn load_splat_m128d(a: &f64) -> m128d {
+pub fn load_f64_splat_m128d(a: &f64) -> m128d {
   m128d(unsafe { _mm_load1_pd(a) })
 }
 

--- a/src/intel/sse4_1.rs
+++ b/src/intel/sse4_1.rs
@@ -494,10 +494,10 @@ macro_rules! dot_product_m128 {
 /// ```
 /// # use safe_arch::*;
 /// let a = m128i::from([5, 6, 7, 8]);
-/// assert_eq!(get_i32_immediate_m128i!(a, 1), 6);
+/// assert_eq!(extract_i32_immediate_m128i!(a, 1), 6);
 /// ```
 #[macro_export]
-macro_rules! get_i32_immediate_m128i {
+macro_rules! extract_i32_immediate_m128i {
   ($a:expr, $imm:expr) => {{
     let a: m128i = $a;
     const IMM: i32 = $imm as i32;
@@ -514,11 +514,11 @@ macro_rules! get_i32_immediate_m128i {
 /// ```
 /// # use safe_arch::*;
 /// let a = m128i::from([5_i64, 6]);
-/// assert_eq!(get_i64_immediate_m128i!(a, 1), 6_i64);
+/// assert_eq!(extract_i64_immediate_m128i!(a, 1), 6_i64);
 /// ```
 #[macro_export]
 #[cfg(target_arch = "x86_64")]
-macro_rules! get_i64_immediate_m128i {
+macro_rules! extract_i64_immediate_m128i {
   ($a:expr, $imm:expr) => {{
     let a: m128i = $a;
     const IMM: i32 = $imm as i32;
@@ -536,10 +536,10 @@ macro_rules! get_i64_immediate_m128i {
 /// # use safe_arch::*;
 /// let a =
 ///   m128i::from([0_i8, 1, 2, 3, 4, 5, 6, 101, 8, 9, 10, 11, 12, 13, 14, 15]);
-/// assert_eq!(get_i8_as_i32_immediate_m128i!(a, 7), 101_i32);
+/// assert_eq!(extract_i8_as_i32_immediate_m128i!(a, 7), 101_i32);
 /// ```
 #[macro_export]
-macro_rules! get_i8_as_i32_immediate_m128i {
+macro_rules! extract_i8_as_i32_immediate_m128i {
   ($a:expr, $imm:expr) => {{
     let a: m128i = $a;
     const IMM: i32 = $imm as i32;
@@ -556,10 +556,13 @@ macro_rules! get_i8_as_i32_immediate_m128i {
 /// ```
 /// # use safe_arch::*;
 /// let a = m128::from_array([5.0, 6.0, 7.0, 8.0]);
-/// assert_eq!(get_f32_as_i32_bits_immediate_m128!(a, 3), 8_f32.to_bits() as i32);
+/// assert_eq!(
+///   extract_f32_as_i32_bits_immediate_m128!(a, 3),
+///   8_f32.to_bits() as i32
+/// );
 /// ```
 #[macro_export]
-macro_rules! get_f32_as_i32_bits_immediate_m128 {
+macro_rules! extract_f32_as_i32_bits_immediate_m128 {
   ($a:expr, $imm:expr) => {{
     let a: m128 = $a;
     const IMM: i32 = $imm as i32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,34 +4,59 @@
 #![allow(clippy::transmute_ptr_to_ptr)]
 #![cfg_attr(docs_rs, feature(doc_cfg))]
 
-//! A crate that safely exposes arch intrinsics via cfg.
+//! A crate that safely exposes arch intrinsics via `#[cfg()]`.
 //!
-//! This crate lets you safely use CPU intrinsics. Those things in
-//! [`core::arch`](core::arch).
-//! * Most of them are 100% safe to use as long as the CPU feature is available,
-//!   like addition and multiplication and stuff.
-//! * Some of them require that you uphold extra alignment requirements or
-//!   whatever, which we do via the type system when necessary.
-//! * Some of them are absolutely not safe at all because it causes UB at the
-//!   LLVM level, so those things are not exposed here.
-//! * Some of them are pointless to expose here because the `core` crate already
-//!   provides the same functionality in a cross-platform way, so we skip those.
-//! * This crate works purely via `cfg` and compile time feature selection,
-//!   there are no runtime checks added. This means that if you _do_ want to do
-//!   runtime feature detection and then dynamically call an intrinsic if it
-//!   happens to be available, then this crate sadly isn't for you.
-//! * This crate aims to be as _minimal_ as possible. Just exposing each
-//!   intrinsic as a safe function with an easier to understand name and some
-//!   minimal docs. Building higher level abstractions on top of the intrinsics
-//!   is the domain of other crates.
-//! * That said, each raw SIMD type is newtype'd as a wrapper (with a `pub`
-//!   field) so that better trait impls can be provided.
+//! `safe_arch` lets you safely use CPU intrinsics. Those things in the
+//! [`core::arch`](core::arch) modules. It works purely via `#[cfg()]` and
+//! compile time CPU feature declaration. If you want to check for a feature at
+//! runtime and then call an intrinsic or use a fallback path based on that then
+//! this crate is sadly not for you.
+//!
+//! SIMD register types are "newtype'd" so that better trait impls can be given
+//! to them, but the inner value is a `pub` field so feel to just grab it out if
+//! you need to. Trait impls of the newtypes include: `Default` (zeroed),
+//! `From`/`Into` of appropriate data types, and appropriate operator
+//! overloading.
+//!
+//! * Most intrinsics (like addition and multiplication) are totally safe to use
+//!   as long as the CPU feature is available. In this case, what you get is 1:1
+//!   with the actual intrinsic.
+//! * Some intrinsics take a pointer of an assumed minimum alignment and
+//!   validity span. For these, the `safe_arch` function takes a reference of an
+//!   appropriate type to uphold safety.
+//!   * Try the [bytemuck](https://docs.rs/bytemuck) crate (and turn on the
+//!     `bytemuck` feature of this crate) if you want help safely casting
+//!     between reference types.
+//! * Some intrinsics are not safe unless you're _very_ careful about how you
+//!   use them, such as the streaming operations requiring you to use them in
+//!   combination with an appropriate memory fence. Those operations aren't
+//!   exposed here.
+//! * Some intrinsics mess with the processor state, such as changing the
+//!   floating point flags, saving and loading special register state, and so
+//!   on. LLVM doesn't really support you messing with that within a high level
+//!   language, so those operations aren't exposed here. Use assembly or
+//!   something if you want to do that.
+//!
+//! ## Naming Conventions
+//! The actual names for each intrinsic are generally a flaming dumpster, so we
+//! use easier to understand names. Well, I hope they're easier to understand.
+//!
+//! * Function names start with the primary "verb" of the operation, and then
+//!   any adverbs go after that. This makes for slightly awkward English but
+//!   helps the list of all the functions sort a little better.
+//!   * Eg: `add_i32_m128i` and `add_i16_saturating_m128i`
+//! * Function names end with the register type they're associated with.
+//!   * Eg: `and_m128` (for `m128`) and `and_m128d` (for `m128d`)
+//! * If a function operates on just the lowest data lane it generally has `_s`
+//!   after the register type, because it's a "scalar" operation. The high(er)
+//!   lane(s) are generally just copied forward, or taken from a secondary
+//!   argument, or something. Details vary.
+//!   * Eg: `sqrt_m128` (all lanes) and `sqrt_m128_s` (low lane only)
 //!
 //! ## Current Support
-//! This grows slowly because there's just _so many_ intrinsics.
-//!
 //! * Intel (`x86` / `x86_64`)
 //!   * 128-bit: `sse`, `sse2`, `sse3`, `ssse3`
+//!   * 256-bit: `avx`
 //!
 //! ## Compile Time CPU Target Features
 //!
@@ -136,26 +161,6 @@ pub mod intel {
   //!
   //! `x86_64` is essentially a superset of `x86`, so we just lump it all into
   //! one module.
-  //!
-  //! ## Naming Conventions
-  //! The actual intrinsic names are a flaming dumpster, so we use easier to
-  //! understand names.
-  //!
-  //! * The general naming scheme is that the operation of the function is
-  //!   followed by the name of the type it operates on:
-  //!   * eg: [`sqrt_m128`], [`add_m128d`]
-  //! * If the function affects only the lowest lane then it has `_s` on the end
-  //!   after the type, because that's a "scalar" operation.
-  //!   * eg: [`add_m128_s`], [`sqrt_m128_s`]
-  //! * Many functions with a "bool-ish" return values have `_mask` in their
-  //!   name. These are the comparison functions, and the return value is all 0s
-  //!   in a lane for "false" in that lane, and all 1s in a lane for "true" in
-  //!   that lane. Because a float or double point value of all 1s is NaN, the
-  //!   mask making functions aren't generally useful on their own, they're just
-  //!   an intermediate value.
-  //!   * eg: [`cmp_eq_mask_m128`], [`cmp_gt_mask_m128`]
-  //! * `convert` functions will round to an approximate numeric value.
-  //! * `cast` functions will preserve the bit patterns involved.
   use super::*;
   #[cfg(target_arch = "x86")]
   use core::arch::x86::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,6 +179,8 @@ pub mod intel {
   submodule!(pub ssse3);
   #[cfg(target_feature = "sse4.1")]
   submodule!(pub sse4_1);
+  #[cfg(target_feature = "avx")]
+  submodule!(pub avx);
 }
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub use intel::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,16 +55,22 @@
 //!   argument, or something. Details vary.
 //!   * Eg: `sqrt_m128` (all lanes) and `sqrt_m128_s` (low lane only)
 //!
-//! Sometimes there's more than one name for essentially the same operation,
-//! because these intrinsics were added to the CPU slowly over a decade or more.
-//! Particularly for going into and out of SIMD form there's the following
-//! naming convention:
-//! * `load` reads from memory into a register.
-//! * `store` writes from a register into memory.
-//! * `set` packs non-SIMD data into a SIMD register.
-//! * `splat` copies a value as many times as it fits across a SIMD register.
-//! * `extract` picks a lane's value out of SIMD into a non-SIMD data type.
-//! * `insert` copies a register and replaces a particular lane's value.
+//! Of course, people can't even always agree on what words mean. The common
+//! verb names for this crate, and their conventions, are as follows:
+//! * `load`: Reads memory into a register (deref `&Foo` to `Foo`).
+//! * `store`: Writes a register to memory (writes `Foo` to a `&mut Foo`).
+//! * `set`: Packs values into a register (works like `[1, 2, 3, 4]` to build an
+//!   array).
+//! * `splat`: Copy a value as many times as possible across the bits of a
+//!   register (works like `[1_i32; LEN]` array building).
+//! * `extract`: Get an individual lane out of a SIMD register (works like array
+//!   access).
+//! * `insert`: Duplicate a register and then replace the value of a specific
+//!   lane (works like `let mut a2 = a.clone(); a2[i] = new;`).
+//! * `cast`: change data types while preserving the exact bit pattern (like how
+//!   `transmute` would do it).
+//! * `convert`: change the container and/or element type while trying to keep
+//!   each number's value as close as possible (like how `as` would do it).
 //!
 //! **This crate is pre-1.0 and if you feel that an operation should have a
 //! better name to improve the crate's consistency please file an issue.**

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,13 +64,14 @@
 //! * `splat`: Copy a value as many times as possible across the bits of a
 //!   register (works like `[1_i32; LEN]` array building).
 //! * `extract`: Get an individual lane out of a SIMD register (works like array
-//!   access).
+//!   access). The lane to get has to be a const value.
 //! * `insert`: Duplicate a register and then replace the value of a specific
-//!   lane (works like `let mut a2 = a.clone(); a2[i] = new;`).
-//! * `cast`: change data types while preserving the exact bit pattern (like how
+//!   lane (works like `let mut a2 = a.clone(); a2[i] = new;`). The lane to
+//!   overwrite has to be a const value.
+//! * `cast`: change data types while preserving the bit pattern (like how
 //!   `transmute` would do it).
-//! * `convert`: change the container and/or element type while trying to keep
-//!   each number's value as close as possible (like how `as` would do it).
+//! * `convert`: change data types while trying to preserve the numeric value
+//!   (which might change the bits, like how `as` would do it).
 //!
 //! **This crate is pre-1.0 and if you feel that an operation should have a
 //! better name to improve the crate's consistency please file an issue.**

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,8 +230,10 @@ pub mod intel {
   //! Types and functions for safe `x86` / `x86_64` intrinsic usage.
   //!
   //! `x86_64` is essentially a superset of `x86`, so we just lump it all into
-  //! one module.
+  //! one module. Anything not available on `x86` simply won't be in the build
+  //! on that arch.
   use super::*;
+
   #[cfg(target_arch = "x86")]
   use core::arch::x86::*;
   #[cfg(target_arch = "x86_64")]
@@ -240,13 +242,18 @@ pub mod intel {
   submodule!(pub m128_);
   submodule!(pub m128d_);
   submodule!(pub m128i_);
+
   submodule!(pub m256_);
   submodule!(pub m256d_);
   submodule!(pub m256i_);
-  // Note(Lokathor): We only include these sub-modules if the feature is enabled
-  // and we *also* cfg attribute on the inside of the modules as a
-  // double-verification of sorts. Technically either way on its own would also
-  // be fine.
+
+  // Note(Lokathor): We only include these sub-modules with the actual functions
+  // if the feature is enabled. Ae *also* have a cfg attribute on the inside of
+  // the modules as a "double-verification" of sorts. Technically either way on
+  // its own would also be fine.
+
+  // These CPU features follow a fairly clear and strict progression that's easy
+  // to remember. Most of them offer a fair pile of new functions.
   #[cfg(target_feature = "sse")]
   submodule!(pub sse);
   #[cfg(target_feature = "sse2")]
@@ -262,6 +269,8 @@ pub mod intel {
   #[cfg(target_feature = "avx")]
   submodule!(pub avx);
 
+  // These features aren't as easy to remember the progression of and they each
+  // only add a small handful of functions.
   #[cfg(target_feature = "adx")]
   submodule!(pub adx);
   #[cfg(target_feature = "aes")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,58 +83,6 @@
 //!   * Other: `adx`, `aes`, `bmi1`, `bmi2`, `lzcnt`, `pclmulqdq`, `popcnt`,
 //!     `rdrand`, `rdseed`
 //!
-//! ## Power License Levels
-//! It sounds like a goofy thing from a video game, but different CPU operations
-//! have a "license level", and this crate makes an attempt to recognize this
-//! concept via cargo feature because it can have a performance impact.
-//! * Any 256-bit multiplication (via either AVX or FMA), as well as all 512-bit
-//!   operations, are "license 1".
-//! * Any 512-bit multiplication is "license 2".
-//! * Any other operation is just "license 0".
-//! * A heavy enough mix of instructions that wouldn't normally demand a higher
-//!   license level individually can still cause a core to request a higher
-//!   license level, as can speculative executions from a failed branch
-//!   prediction.
-//!
-//! If you execute an instruction that's of a _higher_ license level than the
-//! CPU core's current license level then the core greatly slows down while it
-//! negotiates with the power manager that it wants to be at the new higher
-//! license level and drawing more power (this takes up to 500 micro-seconds).
-//!
-//! While the CPU is actually at license 1 or license 2 the core's clock rate is
-//! limited compared to the normal license 0 clock rate. The higher power draw
-//! means more heat, and so the core has to clock down to compensate. Exactly
-//! how much the core has to clock down depends on the CPU and how many cores
-//! are using what license levels and so on. Basically, more power used means
-//! more heat build up means the device has to slow down or it would damage
-//! itself.
-//!
-//! After a while (~2ms) of not executing any higher license level instructions
-//! the CPU core will naturally reduce its license level back down on its own.
-//!
-//! * Dedicated usage of a higher license level feature will generally give an
-//!   overall gain in performance. The core slows down a bit at the start, and
-//!   then runs a little slower than the normal top speed while working, but
-//!   processes through all the lane elements twice as fast and so overall
-//!   there's a gain.
-//! * Occasional usage of a higher license level _can_ make performance worse,
-//!   because the CPU slows down, doesn't do enough work to justify the slow
-//!   down, and then whatever happens after that work is done is _also_ slowed
-//!   until the higher license level "wears off" and things go back to normal.
-//!
-//! So if you want to opt-in to the functions that will demand a higher license
-//! level you have to enable them via the `license1` and `license2` cargo
-//! features. This isn't meant to be a major obstacle, just a tiny reminder.
-//! Even with the cargo features on you must also have the appropriate CPU
-//! feature enabled during the build of course.
-//!
-//! For more details, search the word "license" in the [Intel 64 and IA-32
-//! Architectures Optimization Reference Manual][pdf], it's in section 2.2.3 of
-//! the current version.
-//!
-//! [pdf]:
-//! https://software.intel.com/sites/default/files/managed/9e/bc/64-ia-32-architectures-optimization-manual.pdf
-//!
 //! ## Compile Time CPU Target Features
 //!
 //! At the time of me writing this, Rust enables the `sse` and `sse2` CPU

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,6 +165,9 @@ pub mod intel {
   submodule!(pub m128_);
   submodule!(pub m128d_);
   submodule!(pub m128i_);
+  submodule!(pub m256_);
+  submodule!(pub m256d_);
+  submodule!(pub m256i_);
   // Note(Lokathor): We only include these sub-modules if the feature is enabled
   // and we *also* cfg attribute on the inside of the modules as a
   // double-verification of sorts. Technically either way on its own would also

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,11 +222,8 @@ macro_rules! submodule {
   };
 }
 
-// unlike with the `submodule!` macro, we _want_ to expose the existence these
-// arch-specific modules.
-
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-pub mod intel {
+submodule!(pub intel {
   //! Types and functions for safe `x86` / `x86_64` intrinsic usage.
   //!
   //! `x86_64` is essentially a superset of `x86`, so we just lump it all into
@@ -289,6 +286,4 @@ pub mod intel {
   submodule!(pub rdrand);
   #[cfg(target_feature = "rdseed")]
   submodule!(pub rdseed);
-}
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-pub use intel::*;
+});


### PR DESCRIPTION
* [x] Ensure that avx/sse and avx/sse2 combo intrinsics are properly marked as such.
  * Resolved: the libstd docs are essentially just wrong, LLVM forces on all the features below avx if you turn on avx. It doesn't really have a concept of having avx without sse.
* [x] Decide if we want to dump all content into the top level of the crate or not?
  * Resolved: yes. We're not even 1.0 and also ARM work isn't even into nightly, and I don't even know if anyone is working on it.
---
There was more here but then I pushed things out into their own issues.