### PR TITLE
Minor documentation fix.

### DIFF
--- a/src/x86_x64/avx2.rs
+++ b/src/x86_x64/avx2.rs
@@ -700,7 +700,7 @@ macro_rules! blend_imm_i32_m256i {
 ///   ]
 /// );
 /// ```
-/// * **Intrinsic:** [`_mm256_avg_epu16`]
+/// * **Intrinsic:** [`_mm256_blendv_epi8`]
 /// * **Assembly:** `vpavgw ymm, ymm, ymm`
 #[must_use]
 #[inline(always)]


### PR DESCRIPTION
Comment says `_mm256_avg_epu16`, but the code uses:

https://github.com/Lokathor/safe_arch/blob/36ca5efabcaa4c39a533c1182405fa1c83b9b152/src/x86_x64/avx2.rs#L709