### PR TITLE
chore: exclude some files from published crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,13 @@ edition = "2018"
 license = "Zlib OR Apache-2.0 OR MIT"
 categories = ["api-bindings", "hardware-support", "no-std"]
 keywords = ["intrinsics", "simd"]
+exclude = [
+    "/.cargo/",
+    "/.github/",
+    "/scripts/",
+    "/rustfmt.toml",
+    "/tmp.txt",
+]
 
 [dependencies]
 # If enabled, gives bytemuck trait impls for our types


### PR DESCRIPTION
These all seem to be only useful during development. Excluding them also shaves like 3-4% off of the size when downloading from crates.io.
