### PR TITLE
Fix compile error for `i686-pc-windows-msvc` target

### DIFF
--- a/src/x86_x64/avx512.rs
+++ b/src/x86_x64/avx512.rs
@@ -1,6 +1,8 @@
 #![cfg(target_feature = "avx512f")]
 #![allow(non_camel_case_types)]
 use super::*;
+
+#[cfg(target_arch = "x86_64")]
 use ::core::arch::x86_64::*;
 
 /// Mask type for 8-element operations
@@ -122,7 +124,7 @@ pub fn zeroed_m512() -> m512 {
 
 /// Shuffle the `f64` lanes from `a` and `b` together using an immediate control
 /// value, across all eight double-precision lanes in the ZMM register.
-/// 
+///
 /// # Examples
 /// ```rust
 /// # use safe_arch::*;
@@ -143,7 +145,7 @@ pub fn shuffle_m512d<const IMM: i32>(a: m512d, b: m512d) -> m512d {
 
 /// Shuffle the `f32` lanes from `a` and `b` together using an immediate control
 /// value, across all sixteen single-precision lanes in the ZMM register.
-/// 
+///
 /// # Examples
 /// ```rust
 /// # use safe_arch::*;
@@ -574,7 +576,7 @@ pub fn sub_m512d(a: m512d, b: m512d) -> m512d {
 }
 
 /// Lanewise saturating `a + b` with lanes as signed `i8`.
-/// 
+///
 /// # Examples
 /// ```rust
 /// # use safe_arch::*;
@@ -839,7 +841,7 @@ pub fn mul_u32_wide_m512i(a: m512i, b: m512i) -> m512i {
 /// let c2: [i16; 32] = mul_i16_keep_high_m512i(a2, b).into();
 /// assert_eq!(c2, [(-0x1000_i16); 32]);
 /// ```
-/// * **Intrinsic:** [`_mm512_mulhi_epi16`]  
+/// * **Intrinsic:** [`_mm512_mulhi_epi16`]
 /// * **Assembly:** `vpmulhw zmm, zmm, zmm`
 #[must_use]
 #[inline(always)]
@@ -859,15 +861,15 @@ pub fn mul_i16_keep_high_m512i(a: m512i, b: m512i) -> m512i {
 /// let c: [u16; 32] = mul_u16_keep_high_m512i(a, b).into();
 /// assert_eq!(c, [0x4000_u16; 32]);
 ///
-/// // A mixed‐value test:  
+/// // A mixed‐value test:
 /// let a2 = set_splat_i16_m512i(0x1234);
 /// let b2 = set_splat_i16_m512i(0x00FF);
-/// // 0x1234×0x00FF = 0x1234 × 255 = 0x1234×0x00FF = 0x1234×0x00FF = 0x1234×0x00FF = 0x2FE * 0x100 + ... 
+/// // 0x1234×0x00FF = 0x1234 × 255 = 0x1234×0x00FF = 0x1234×0x00FF = 0x1234×0x00FF = 0x2FE * 0x100 + ...
 /// // actually 0x1234=4660, ×255=1_188_300 = 0x122A6C → high16 = 0x0012 (18)
 /// let c2: [u16; 32] = mul_u16_keep_high_m512i(a2, b2).into();
 /// assert_eq!(c2, [0x0012_u16; 32]);
 /// ```
-/// * **Intrinsic:** [`_mm512_mulhi_epu16`]  
+/// * **Intrinsic:** [`_mm512_mulhi_epu16`]
 /// * **Assembly:** `vpmulhuw zmm, zmm, zmm`
 #[must_use]
 #[inline(always)]
@@ -1154,7 +1156,7 @@ pub fn fused_mul_sub_add_m512d(a: m512d, b: m512d, c: m512d) -> m512d {
 /// let m = cmp_op_mask_i8::<{ ::core::arch::x86_64::_MM_CMPINT_EQ }>(a, b);
 /// assert_eq!(m, u64::MAX);
 /// ```
-/// * **Intrinsic:** `_mm512_cmp_epi8_mask`  
+/// * **Intrinsic:** `_mm512_cmp_epi8_mask`
 /// * **Assembly:** `VPCMPB k, zmm, zmm, imm8`
 #[must_use] #[inline(always)]
 #[cfg(target_feature = "avx512bw")]
@@ -1171,7 +1173,7 @@ pub fn cmp_op_mask_i8<const OP: i32>(a: m512i, b: m512i) -> mmask64 {
 /// let m = cmp_op_mask_u8::<{ ::core::arch::x86_64::_MM_CMPINT_LT }>(a, b);
 /// assert_eq!(m, u64::MAX);
 /// ```
-/// * **Intrinsic:** `_mm512_cmp_epu8_mask`  
+/// * **Intrinsic:** `_mm512_cmp_epu8_mask`
 /// * **Assembly:** `VPCMPUB k, zmm, zmm, imm8`
 #[must_use] #[inline(always)]
 #[cfg(target_feature = "avx512bw")]
@@ -1187,7 +1189,7 @@ pub fn cmp_op_mask_u8<const OP: i32>(a: m512i, b: m512i) -> mmask64 {
 /// let m = cmp_op_mask_i16::<{ ::core::arch::x86_64::_MM_CMPINT_EQ }>(a, b);
 /// assert_eq!(m, u32::MAX);
 /// ```
-/// * **Intrinsic:** `_mm512_cmp_epi16_mask`  
+/// * **Intrinsic:** `_mm512_cmp_epi16_mask`
 /// * **Assembly:** `VPCMPW k, zmm, zmm, imm8`
 #[must_use] #[inline(always)]
 #[cfg(target_feature = "avx512bw")]
@@ -1204,7 +1206,7 @@ pub fn cmp_op_mask_i16<const OP: i32>(a: m512i, b: m512i) -> mmask32 {
 /// let m = cmp_op_mask_u16::<{ ::core::arch::x86_64::_MM_CMPINT_LE }>(a, b);
 /// assert_eq!(m, u32::MAX);
 /// ```
-/// * **Intrinsic:** `_mm512_cmp_epu16_mask`  
+/// * **Intrinsic:** `_mm512_cmp_epu16_mask`
 /// * **Assembly:** `VPCMPUW k, zmm, zmm, imm8`
 #[must_use] #[inline(always)]
 #[cfg(target_feature = "avx512bw")]
@@ -1221,7 +1223,7 @@ pub fn cmp_op_mask_u16<const OP: i32>(a: m512i, b: m512i) -> mmask32 {
 /// let m = cmp_op_mask_i32::<{ ::core::arch::x86_64::_MM_CMPINT_LT }>(b, a);
 /// assert_eq!(m, u16::MAX);
 /// ```
-/// * **Intrinsic:** `_mm512_cmp_epi32_mask`  
+/// * **Intrinsic:** `_mm512_cmp_epi32_mask`
 /// * **Assembly:** `VPCMPD k, zmm, zmm, imm8`
 #[must_use] #[inline(always)]
 #[cfg(target_feature = "avx512f")]
@@ -1238,7 +1240,7 @@ pub fn cmp_op_mask_i32<const OP: i32>(a: m512i, b: m512i) -> mmask16 {
 /// let m = cmp_op_mask_u32::<{ ::core::arch::x86_64::_MM_CMPINT_LT }>(a, b);
 /// assert_eq!(m, u16::MAX);
 /// ```
-/// * **Intrinsic:** `_mm512_cmp_epu32_mask`  
+/// * **Intrinsic:** `_mm512_cmp_epu32_mask`
 /// * **Assembly:** `VPCMPUD k, zmm, zmm, imm8`
 #[must_use] #[inline(always)]
 #[cfg(target_feature = "avx512f")]
@@ -1254,7 +1256,7 @@ pub fn cmp_op_mask_u32<const OP: i32>(a: m512i, b: m512i) -> mmask16 {
 /// let m = cmp_op_mask_i64::<{ ::core::arch::x86_64::_MM_CMPINT_EQ }>(a, b);
 /// assert_eq!(m, u8::MAX);
 /// ```
-/// * **Intrinsic:** `_mm512_cmp_epi64_mask`  
+/// * **Intrinsic:** `_mm512_cmp_epi64_mask`
 /// * **Assembly:** `VPCMPQ k, zmm, zmm, imm8`
 #[must_use] #[inline(always)]
 #[cfg(target_feature = "avx512f")]
@@ -1271,7 +1273,7 @@ pub fn cmp_op_mask_i64<const OP: i32>(a: m512i, b: m512i) -> mmask8 {
 /// let m = cmp_op_mask_u64::<{ ::core::arch::x86_64::_MM_CMPINT_LE }>(a, b);
 /// assert_eq!(m, u8::MAX);
 /// ```
-/// * **Intrinsic:** `_mm512_cmp_epu64_mask`  
+/// * **Intrinsic:** `_mm512_cmp_epu64_mask`
 /// * **Assembly:** `VPCMPUQ k, zmm, zmm, imm8`
 #[must_use] #[inline(always)]
 #[cfg(target_feature = "avx512f")]
@@ -1288,7 +1290,7 @@ pub fn cmp_op_mask_u64<const OP: i32>(a: m512i, b: m512i) -> mmask8 {
 /// let m = cmp_op_mask_f32::<{ ::core::arch::x86_64::_MM_CMPINT_LT }>(a, b);
 /// assert_eq!(m, u16::MAX);
 /// ```
-/// * **Intrinsic:** `_mm512_cmp_ps_mask`  
+/// * **Intrinsic:** `_mm512_cmp_ps_mask`
 /// * **Assembly:** `VPCMPPS k, zmm, zmm, imm8`
 #[must_use] #[inline(always)]
 #[cfg(target_feature = "avx512f")]
@@ -1304,7 +1306,7 @@ pub fn cmp_op_mask_f32<const OP: i32>(a: m512, b: m512) -> mmask16 {
 /// let m = cmp_op_mask_f64::<{ ::core::arch::x86_64::_MM_CMPINT_EQ }>(a, b);
 /// assert_eq!(m, u8::MAX);
 /// ```
-/// * **Intrinsic:** `_mm512_cmp_pd_mask`  
+/// * **Intrinsic:** `_mm512_cmp_pd_mask`
 /// * **Assembly:** `VPCMPPD k, zmm, zmm, imm8`
 #[must_use] #[inline(always)]
 #[cfg(target_feature = "avx512f")]
@@ -1968,7 +1970,7 @@ pub fn convert_to_i32_m512i_from_i16_m256i(a: m256i) -> m512i {
 }
 
 /// Convert `u16` values to `u32` values (zero-extend).
-/// 
+///
 /// # Examples
 /// ```rust
 /// # use safe_arch::*;
@@ -2077,7 +2079,7 @@ pub fn convert_truncate_m512d_i64_m512i(a: m512d) -> m512i {
 /// assert_eq!(b, [3.0_f64; 8]);
 /// ```
 /// * **Intrinsic:** [`_mm512_cvtepi32_pd`]
-/// * **Assembly:** `vcvtdq2pd zmm, ymm`  
+/// * **Assembly:** `vcvtdq2pd zmm, ymm`
 #[must_use]
 #[inline(always)]
 #[cfg_attr(docsrs, doc(cfg(target_feature = "avx512f")))]
@@ -2597,7 +2599,7 @@ pub fn shr_all_u64_m512i(a: m512i, count: u64) -> m512i {
 }
 
 /// Absolute value of `i8` lanes in a 512-bit integer vector.
-/// 
+///
 /// # Examples
 /// ```rust
 /// # use safe_arch::*;
@@ -2615,7 +2617,7 @@ pub fn abs_i8_m512i(a: m512i) -> m512i {
 }
 
 /// Absolute value of `i16` lanes in a 512-bit integer vector.
-/// 
+///
 /// # Examples
 /// ```rust
 /// # use safe_arch::*;
@@ -2633,7 +2635,7 @@ pub fn abs_i16_m512i(a: m512i) -> m512i {
 }
 
 /// Absolute value of `i32` lanes in a 512-bit integer vector.
-/// 
+///
 /// # Examples
 /// ```rust
 /// # use safe_arch::*;
@@ -3100,7 +3102,7 @@ pub fn insert_m256d_to_m512d<const LANE: i32>(a: m512d, b: m256d) -> m512d {
 /// let none = maskz_mov_f32_m512(0);
 /// assert_eq!(none, set_splat_m512(0.0));
 /// ```
-/// * **Intrinsic:** `_mm512_maskz_mov_ps`  
+/// * **Intrinsic:** `_mm512_maskz_mov_ps`
 /// * **Assembly:** `VMOVDQU32 zmm{dest}{mask}{z}, zmmones`
 #[must_use]
 #[inline(always)]
@@ -3120,7 +3122,7 @@ pub fn maskz_mov_f32_m512(mask: mmask16) -> m512 {
 /// let none = maskz_mov_f64_m512d(0);
 /// assert_eq!(none, set_splat_m512d(0.0));
 /// ```
-/// * **Intrinsic:** `_mm512_maskz_mov_pd`  
+/// * **Intrinsic:** `_mm512_maskz_mov_pd`
 /// * **Assembly:** `VMOVDQU64 zmm{dest}{mask}{z}, zmmones`
 #[must_use]
 #[inline(always)]
@@ -3140,7 +3142,7 @@ pub fn maskz_mov_f64_m512d(mask: mmask8) -> m512d {
 /// let none = maskz_mov_i64_m512i(0);
 /// assert_eq!(none, set_splat_i64_m512i(0));
 /// ```
-/// * **Intrinsic:** `_mm512_maskz_mov_epi64`  
+/// * **Intrinsic:** `_mm512_maskz_mov_epi64`
 /// * **Assembly:** `VMOVDQU64 zmm{dest}{mask}{z}, zmmones`
 #[must_use]
 #[inline(always)]
@@ -3160,7 +3162,7 @@ pub fn maskz_mov_i64_m512i(mask: mmask8) -> m512i {
 /// let none = maskz_mov_i32_m512i(0);
 /// assert_eq!(none, set_splat_i32_m512i(0));
 /// ```
-/// * **Intrinsic:** `_mm512_maskz_mov_epi32`  
+/// * **Intrinsic:** `_mm512_maskz_mov_epi32`
 /// * **Assembly:** `VMOVDQU32 zmm{dest}{mask}{z}, zmmones`
 #[must_use]
 #[inline(always)]
@@ -3180,7 +3182,7 @@ pub fn maskz_mov_i32_m512i(mask: mmask16) -> m512i {
 /// let none = maskz_mov_i16_m512i(0);
 /// assert_eq!(none.to_array(), [0; 16]);
 /// ```
-/// * **Intrinsic:** `_mm512_maskz_mov_epi16`  
+/// * **Intrinsic:** `_mm512_maskz_mov_epi16`
 /// * **Assembly:** `VMOVDQU16 zmm{dest}{mask}{z}, zmmones`
 #[must_use]
 #[inline(always)]
@@ -3200,7 +3202,7 @@ pub fn maskz_mov_i16_m512i(mask: mmask32) -> m512i {
 /// let none = maskz_mov_i8_m512i(0);
 /// assert_eq!(none, set_splat_i8_m512i(0));
 /// ```
-/// * **Intrinsic:** `_mm512_maskz_mov_epi8`  
+/// * **Intrinsic:** `_mm512_maskz_mov_epi8`
 /// * **Assembly:** `VMOVDQU8 zmm{dest}{mask}{z}, zmmones`
 #[must_use]
 #[inline(always)]
@@ -3401,7 +3403,7 @@ pub fn permute_i32_m512i(idx: m512i, a: m512i) -> m512i {
 /// assert_eq!(r_zero, [1.0, 2.0, -1.0, -2.0, 3.0, -3.0, 4.0, -4.0]);
 /// ```
 /// * **Intrinsic:** [`_mm512_roundscale_pd`]
-/// * **Assembly:** `vrndscalepd zmm, zmm, imm8`  
+/// * **Assembly:** `vrndscalepd zmm, zmm, imm8`
 #[must_use]
 #[inline(always)]
 #[cfg_attr(docsrs, doc(cfg(target_feature = "avx512f")))]
@@ -3429,7 +3431,7 @@ pub fn round_m512d<const OP: i32>(a: m512d) -> m512d {
 /// assert_eq!(&r_zero[0..4], &[1.0, 2.0, -1.0, -2.0]);
 /// ```
 /// * **Intrinsic:** [`_mm512_roundscale_ps`]
-/// * **Assembly:** `vrndscaleps zmm, zmm, imm8`  
+/// * **Assembly:** `vrndscaleps zmm, zmm, imm8`
 #[must_use]
 #[inline(always)]
 #[cfg_attr(docsrs, doc(cfg(target_feature = "avx512f")))]
@@ -3591,7 +3593,7 @@ pub fn max_u32_m512i(a: m512i, b: m512i) -> m512i {
 }
 
 /// Lanewise maximum for signed `i64` lanes.
-/// 
+///
 /// # Examples
 /// ```rust
 /// # use safe_arch::*;
@@ -3600,7 +3602,7 @@ pub fn max_u32_m512i(a: m512i, b: m512i) -> m512i {
 /// let c: [i64; 8] = max_i64_m512i(a, b).into();
 /// assert_eq!(c, [2_i64; 8]);
 /// ```
-/// * **Intrinsic:** [`_mm512_max_epi64`] :contentReference[oaicite:0]{index=0}  
+/// * **Intrinsic:** [`_mm512_max_epi64`] :contentReference[oaicite:0]{index=0}
 /// * **Assembly:** `vpmaxsq zmm, zmm, zmm`
 #[must_use] #[inline(always)]
 #[cfg_attr(docsrs, doc(cfg(target_feature = "avx512f")))]
@@ -3609,7 +3611,7 @@ pub fn max_i64_m512i(a: m512i, b: m512i) -> m512i {
 }
 
 /// Lanewise maximum for unsigned `u64` lanes.
-/// 
+///
 /// # Examples
 /// ```rust
 /// # use safe_arch::*;
@@ -3618,7 +3620,7 @@ pub fn max_i64_m512i(a: m512i, b: m512i) -> m512i {
 /// let c: [u64; 8] = max_u64_m512i(a, b).into();
 /// assert_eq!(c, [5_u64; 8]);
 /// ```
-/// * **Intrinsic:** [`_mm512_max_epu64`] :contentReference[oaicite:1]{index=1}  
+/// * **Intrinsic:** [`_mm512_max_epu64`] :contentReference[oaicite:1]{index=1}
 /// * **Assembly:** `vpmaxuq zmm, zmm, zmm`
 #[must_use] #[inline(always)]
 #[cfg_attr(docsrs, doc(cfg(target_feature = "avx512f")))]
@@ -3723,7 +3725,7 @@ pub fn min_u32_m512i(a: m512i, b: m512i) -> m512i {
 }
 
 /// Lanewise minimum for signed `i64` lanes.
-/// 
+///
 /// # Examples
 /// ```rust
 /// # use safe_arch::*;
@@ -3732,7 +3734,7 @@ pub fn min_u32_m512i(a: m512i, b: m512i) -> m512i {
 /// let c: [i64; 8] = min_i64_m512i(a, b).into();
 /// assert_eq!(c, [-5_i64; 8]);
 /// ```
-/// * **Intrinsic:** [`_mm512_min_epi64`] :contentReference[oaicite:2]{index=2}  
+/// * **Intrinsic:** [`_mm512_min_epi64`] :contentReference[oaicite:2]{index=2}
 /// * **Assembly:** `vpminsq zmm, zmm, zmm`
 #[must_use] #[inline(always)]
 #[cfg_attr(docsrs, doc(cfg(target_feature = "avx512f")))]
@@ -3741,7 +3743,7 @@ pub fn min_i64_m512i(a: m512i, b: m512i) -> m512i {
 }
 
 /// Lanewise minimum for unsigned `u64` lanes.
-/// 
+///
 /// # Examples
 /// ```rust
 /// # use safe_arch::*;
@@ -3750,7 +3752,7 @@ pub fn min_i64_m512i(a: m512i, b: m512i) -> m512i {
 /// let c: [u64; 8] = min_u64_m512i(a, b).into();
 /// assert_eq!(c, [1_u64; 8]);
 /// ```
-/// * **Intrinsic:** [`_mm512_min_epu64`] :contentReference[oaicite:3]{index=3}  
+/// * **Intrinsic:** [`_mm512_min_epu64`] :contentReference[oaicite:3]{index=3}
 /// * **Assembly:** `vpminuq zmm, zmm, zmm`
 #[must_use] #[inline(always)]
 #[cfg_attr(docsrs, doc(cfg(target_feature = "avx512f")))]

--- a/src/x86_x64/avx512.rs
+++ b/src/x86_x64/avx512.rs
@@ -2,6 +2,8 @@
 #![allow(non_camel_case_types)]
 use super::*;
 
+#[cfg(target_arch = "x86")]
+use ::core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use ::core::arch::x86_64::*;
 

--- a/src/x86_x64/avx512.rs
+++ b/src/x86_x64/avx512.rs
@@ -1153,6 +1153,10 @@ pub fn fused_mul_sub_add_m512d(a: m512d, b: m512d, c: m512d) -> m512d {
 /// Compare `i8` lanes under `OP`, returning a 64-bit mask.
 /// ```rust
 /// # use safe_arch::*;
+/// #[cfg(target_arch = "x86")]
+/// use ::core::arch::x86::*;
+/// #[cfg(target_arch = "x86_64")]
+/// use ::core::arch::x86_64::*;
 /// let a = set_splat_i8_m512i(5);
 /// let b = set_splat_i8_m512i(5);
 /// let m = cmp_op_mask_i8::<{ _MM_CMPINT_EQ }>(a, b);
@@ -1169,6 +1173,10 @@ pub fn cmp_op_mask_i8<const OP: i32>(a: m512i, b: m512i) -> mmask64 {
 /// Compare `u8` lanes under `OP`, returning a 64-bit mask.
 /// ```rust
 /// # use safe_arch::*;
+/// #[cfg(target_arch = "x86")]
+/// use ::core::arch::x86::*;
+/// #[cfg(target_arch = "x86_64")]
+/// use ::core::arch::x86_64::*;
 /// let a = set_splat_i8_m512i(3);
 /// let b = set_splat_i8_m512i(5);
 /// // unsigned <  → 3<5
@@ -1186,6 +1194,10 @@ pub fn cmp_op_mask_u8<const OP: i32>(a: m512i, b: m512i) -> mmask64 {
 /// Compare `i16` lanes under `OP`, returning a 32-bit mask.
 /// ```rust
 /// # use safe_arch::*;
+/// #[cfg(target_arch = "x86")]
+/// use ::core::arch::x86::*;
+/// #[cfg(target_arch = "x86_64")]
+/// use ::core::arch::x86_64::*;
 /// let a = set_splat_i16_m512i(5);
 /// let b = set_splat_i16_m512i(5);
 /// let m = cmp_op_mask_i16::<{ _MM_CMPINT_EQ }>(a, b);
@@ -1202,6 +1214,10 @@ pub fn cmp_op_mask_i16<const OP: i32>(a: m512i, b: m512i) -> mmask32 {
 /// Compare `u16` lanes under `OP`, returning a 32-bit mask.
 /// ```rust
 /// # use safe_arch::*;
+/// #[cfg(target_arch = "x86")]
+/// use ::core::arch::x86::*;
+/// #[cfg(target_arch = "x86_64")]
+/// use ::core::arch::x86_64::*;
 /// let a = set_splat_i16_m512i(3);
 /// let b = set_splat_i16_m512i(5);
 /// // unsigned <= → 3<=5
@@ -1219,6 +1235,10 @@ pub fn cmp_op_mask_u16<const OP: i32>(a: m512i, b: m512i) -> mmask32 {
 /// Compare `i32` lanes under `OP`, returning a 16-bit mask.
 /// ```rust
 /// # use safe_arch::*;
+/// #[cfg(target_arch = "x86")]
+/// use ::core::arch::x86::*;
+/// #[cfg(target_arch = "x86_64")]
+/// use ::core::arch::x86_64::*;
 /// let a = set_splat_i32_m512i(5);
 /// let b = set_splat_i32_m512i(2);
 /// // signed > → 5>2
@@ -1236,6 +1256,10 @@ pub fn cmp_op_mask_i32<const OP: i32>(a: m512i, b: m512i) -> mmask16 {
 /// Compare `u32` lanes under `OP`, returning a 16-bit mask.
 /// ```rust
 /// # use safe_arch::*;
+/// #[cfg(target_arch = "x86")]
+/// use ::core::arch::x86::*;
+/// #[cfg(target_arch = "x86_64")]
+/// use ::core::arch::x86_64::*;
 /// let a = set_splat_i32_m512i(2);
 /// let b = set_splat_i32_m512i(5);
 /// // unsigned < → 2<5
@@ -1253,6 +1277,10 @@ pub fn cmp_op_mask_u32<const OP: i32>(a: m512i, b: m512i) -> mmask16 {
 /// Compare `i64` lanes under `OP`, returning an 8-bit mask.
 /// ```rust
 /// # use safe_arch::*;
+/// #[cfg(target_arch = "x86")]
+/// use ::core::arch::x86::*;
+/// #[cfg(target_arch = "x86_64")]
+/// use ::core::arch::x86_64::*;
 /// let a = set_splat_i64_m512i(5);
 /// let b = set_splat_i64_m512i(5);
 /// let m = cmp_op_mask_i64::<{ _MM_CMPINT_EQ }>(a, b);
@@ -1269,6 +1297,10 @@ pub fn cmp_op_mask_i64<const OP: i32>(a: m512i, b: m512i) -> mmask8 {
 /// Compare `u64` lanes under `OP`, returning an 8-bit mask.
 /// ```rust
 /// # use safe_arch::*;
+/// #[cfg(target_arch = "x86")]
+/// use ::core::arch::x86::*;
+/// #[cfg(target_arch = "x86_64")]
+/// use ::core::arch::x86_64::*;
 /// let a = set_splat_i64_m512i(3);
 /// let b = set_splat_i64_m512i(5);
 /// // unsigned <= → 3<=5
@@ -1286,6 +1318,10 @@ pub fn cmp_op_mask_u64<const OP: i32>(a: m512i, b: m512i) -> mmask8 {
 /// Compare `f32` lanes under `OP`, returning a 16-bit mask.
 /// ```rust
 /// # use safe_arch::*;
+/// #[cfg(target_arch = "x86")]
+/// use ::core::arch::x86::*;
+/// #[cfg(target_arch = "x86_64")]
+/// use ::core::arch::x86_64::*;
 /// let a = set_splat_m512(3.0);
 /// let b = set_splat_m512(5.0);
 /// // < : 3<5
@@ -1303,6 +1339,10 @@ pub fn cmp_op_mask_f32<const OP: i32>(a: m512, b: m512) -> mmask16 {
 /// Compare `f64` lanes under `OP`, returning an 8-bit mask.
 /// ```rust
 /// # use safe_arch::*;
+/// #[cfg(target_arch = "x86")]
+/// use ::core::arch::x86::*;
+/// #[cfg(target_arch = "x86_64")]
+/// use ::core::arch::x86_64::*;
 /// let a = set_splat_m512d(3.0);
 /// let b = set_splat_m512d(3.0);
 /// let m = cmp_op_mask_f64::<{ _MM_CMPINT_EQ }>(a, b);
@@ -1323,6 +1363,10 @@ pub fn cmp_op_mask_f64<const OP: i32>(a: m512d, b: m512d) -> mmask8 {
 /// `i8` version: expands your `mmask64` into a `m512i` of all-ones or zeros.
 /// ```rust
 /// # use safe_arch::*;
+/// #[cfg(target_arch = "x86")]
+/// use ::core::arch::x86::*;
+/// #[cfg(target_arch = "x86_64")]
+/// use ::core::arch::x86_64::*;
 /// let a = set_splat_i8_m512i(5);
 /// let b = set_splat_i8_m512i(5);
 /// let v = cmp_op_mask_i8_m512i::<{ _MM_CMPINT_EQ }>(a, b);
@@ -1340,6 +1384,10 @@ pub fn cmp_op_mask_i8_m512i<const OP: i32>(a: m512i, b: m512i) -> m512i {
 /// `u8` version: expands your `mmask64` into a `m512i` of all-ones or zeros.
 /// ```rust
 /// # use safe_arch::*;
+/// #[cfg(target_arch = "x86")]
+/// use ::core::arch::x86::*;
+/// #[cfg(target_arch = "x86_64")]
+/// use ::core::arch::x86_64::*;
 /// let a = set_splat_i8_m512i(3);
 /// let b = set_splat_i8_m512i(5);
 /// let v = cmp_op_mask_u8_m512i::<{ _MM_CMPINT_LT }>(a, b);
@@ -1357,6 +1405,10 @@ pub fn cmp_op_mask_u8_m512i<const OP: i32>(a: m512i, b: m512i) -> m512i {
 /// `i16` version: expands your `mmask32` into a `m512i` of all-ones or zeros.
 /// ```rust
 /// # use safe_arch::*;
+/// #[cfg(target_arch = "x86")]
+/// use ::core::arch::x86::*;
+/// #[cfg(target_arch = "x86_64")]
+/// use ::core::arch::x86_64::*;
 /// let a = set_splat_i16_m512i(5);
 /// let b = set_splat_i16_m512i(5);
 /// let v = cmp_op_mask_i16_m512i::<{ _MM_CMPINT_EQ }>(a, b);
@@ -1374,6 +1426,10 @@ pub fn cmp_op_mask_i16_m512i<const OP: i32>(a: m512i, b: m512i) -> m512i {
 /// `u16` version: expands your `mmask32` into a `m512i` of all-ones or zeros.
 /// ```rust
 /// # use safe_arch::*;
+/// #[cfg(target_arch = "x86")]
+/// use ::core::arch::x86::*;
+/// #[cfg(target_arch = "x86_64")]
+/// use ::core::arch::x86_64::*;
 /// let a = set_splat_i16_m512i(3);
 /// let b = set_splat_i16_m512i(5);
 /// let v = cmp_op_mask_u16_m512i::<{ _MM_CMPINT_LE }>(a, b);
@@ -1391,6 +1447,10 @@ pub fn cmp_op_mask_u16_m512i<const OP: i32>(a: m512i, b: m512i) -> m512i {
 /// `i32` version: expands your `mmask16` into a `m512i` of all-ones or zeros.
 /// ```rust
 /// # use safe_arch::*;
+/// #[cfg(target_arch = "x86")]
+/// use ::core::arch::x86::*;
+/// #[cfg(target_arch = "x86_64")]
+/// use ::core::arch::x86_64::*;
 /// let a = set_splat_i32_m512i(5);
 /// let b = set_splat_i32_m512i(2);
 /// let v = cmp_op_mask_i32_m512i::<{ _MM_CMPINT_LT }>(b, a);
@@ -1408,6 +1468,10 @@ pub fn cmp_op_mask_i32_m512i<const OP: i32>(a: m512i, b: m512i) -> m512i {
 /// `u32` version: expands your `mmask16` into a `m512i` of all-ones or zeros.
 /// ```rust
 /// # use safe_arch::*;
+/// #[cfg(target_arch = "x86")]
+/// use ::core::arch::x86::*;
+/// #[cfg(target_arch = "x86_64")]
+/// use ::core::arch::x86_64::*;
 /// let a = set_splat_i32_m512i(2);
 /// let b = set_splat_i32_m512i(5);
 /// let v = cmp_op_mask_u32_m512i::<{ _MM_CMPINT_LT }>(a, b);
@@ -1425,6 +1489,10 @@ pub fn cmp_op_mask_u32_m512i<const OP: i32>(a: m512i, b: m512i) -> m512i {
 /// `i64` version: expands your `mmask8` into a `m512i` of all-ones or zeros.
 /// ```rust
 /// # use safe_arch::*;
+/// #[cfg(target_arch = "x86")]
+/// use ::core::arch::x86::*;
+/// #[cfg(target_arch = "x86_64")]
+/// use ::core::arch::x86_64::*;
 /// let a = set_splat_i64_m512i(5);
 /// let b = set_splat_i64_m512i(5);
 /// let v = cmp_op_mask_i64_m512i::<{ _MM_CMPINT_EQ }>(a, b);
@@ -1442,6 +1510,10 @@ pub fn cmp_op_mask_i64_m512i<const OP: i32>(a: m512i, b: m512i) -> m512i {
 /// `u64` version: expands your `mmask8` into a `m512i` of all-ones or zeros.
 /// ```rust
 /// # use safe_arch::*;
+/// #[cfg(target_arch = "x86")]
+/// use ::core::arch::x86::*;
+/// #[cfg(target_arch = "x86_64")]
+/// use ::core::arch::x86_64::*;
 /// let a = set_splat_i64_m512i(3);
 /// let b = set_splat_i64_m512i(5);
 /// let v = cmp_op_mask_u64_m512i::<{ _MM_CMPINT_LE }>(a, b);
@@ -1459,6 +1531,10 @@ pub fn cmp_op_mask_u64_m512i<const OP: i32>(a: m512i, b: m512i) -> m512i {
 /// `f32` version: expands your `mmask16` into a `m512` of all-ones or zeros.
 /// ```rust
 /// # use safe_arch::*;
+/// #[cfg(target_arch = "x86")]
+/// use ::core::arch::x86::*;
+/// #[cfg(target_arch = "x86_64")]
+/// use ::core::arch::x86_64::*;
 /// let a = set_splat_m512(3.0);
 /// let b = set_splat_m512(5.0);
 /// let v = cmp_op_mask_m512::<{ _MM_CMPINT_LT }>(a, b);
@@ -1479,6 +1555,10 @@ pub fn cmp_op_mask_m512<const OP: i32>(a: m512, b: m512) -> m512 {
 /// `f64` version: expands your `mmask8` into a `m512d` of all-ones or zeros.
 /// ```rust
 /// # use safe_arch::*;
+/// #[cfg(target_arch = "x86")]
+/// use ::core::arch::x86::*;
+/// #[cfg(target_arch = "x86_64")]
+/// use ::core::arch::x86_64::*;
 /// let a = set_splat_m512d(3.0);
 /// let b = set_splat_m512d(3.0);
 /// let v = cmp_op_mask_m512d::<{ _MM_CMPINT_EQ }>(a, b);
@@ -3392,6 +3472,10 @@ pub fn permute_i32_m512i(idx: m512i, a: m512i) -> m512i {
 /// # Examples
 /// ```rust
 /// # use safe_arch::*;
+/// #[cfg(target_arch = "x86")]
+/// use ::core::arch::x86::*;
+/// #[cfg(target_arch = "x86_64")]
+/// use ::core::arch::x86_64::*;
 /// let a = m512d::from([
 ///     1.3,  2.7, -1.3, -2.7,
 ///     3.5, -3.5,  4.1, -4.9,
@@ -3418,6 +3502,10 @@ pub fn round_m512d<const OP: i32>(a: m512d) -> m512d {
 /// # Examples
 /// ```rust
 /// # use safe_arch::*;
+/// #[cfg(target_arch = "x86")]
+/// use ::core::arch::x86::*;
+/// #[cfg(target_arch = "x86_64")]
+/// use ::core::arch::x86_64::*;
 /// let a = m512::from([
 ///     1.3,  2.7, -1.3, -2.7,
 ///     3.5, -3.5,  4.1, -4.9,

--- a/src/x86_x64/avx512.rs
+++ b/src/x86_x64/avx512.rs
@@ -1155,7 +1155,7 @@ pub fn fused_mul_sub_add_m512d(a: m512d, b: m512d, c: m512d) -> m512d {
 /// # use safe_arch::*;
 /// let a = set_splat_i8_m512i(5);
 /// let b = set_splat_i8_m512i(5);
-/// let m = cmp_op_mask_i8::<{ ::core::arch::x86_64::_MM_CMPINT_EQ }>(a, b);
+/// let m = cmp_op_mask_i8::<{ _MM_CMPINT_EQ }>(a, b);
 /// assert_eq!(m, u64::MAX);
 /// ```
 /// * **Intrinsic:** `_mm512_cmp_epi8_mask`
@@ -1172,7 +1172,7 @@ pub fn cmp_op_mask_i8<const OP: i32>(a: m512i, b: m512i) -> mmask64 {
 /// let a = set_splat_i8_m512i(3);
 /// let b = set_splat_i8_m512i(5);
 /// // unsigned <  → 3<5
-/// let m = cmp_op_mask_u8::<{ ::core::arch::x86_64::_MM_CMPINT_LT }>(a, b);
+/// let m = cmp_op_mask_u8::<{ _MM_CMPINT_LT }>(a, b);
 /// assert_eq!(m, u64::MAX);
 /// ```
 /// * **Intrinsic:** `_mm512_cmp_epu8_mask`
@@ -1188,7 +1188,7 @@ pub fn cmp_op_mask_u8<const OP: i32>(a: m512i, b: m512i) -> mmask64 {
 /// # use safe_arch::*;
 /// let a = set_splat_i16_m512i(5);
 /// let b = set_splat_i16_m512i(5);
-/// let m = cmp_op_mask_i16::<{ ::core::arch::x86_64::_MM_CMPINT_EQ }>(a, b);
+/// let m = cmp_op_mask_i16::<{ _MM_CMPINT_EQ }>(a, b);
 /// assert_eq!(m, u32::MAX);
 /// ```
 /// * **Intrinsic:** `_mm512_cmp_epi16_mask`
@@ -1205,7 +1205,7 @@ pub fn cmp_op_mask_i16<const OP: i32>(a: m512i, b: m512i) -> mmask32 {
 /// let a = set_splat_i16_m512i(3);
 /// let b = set_splat_i16_m512i(5);
 /// // unsigned <= → 3<=5
-/// let m = cmp_op_mask_u16::<{ ::core::arch::x86_64::_MM_CMPINT_LE }>(a, b);
+/// let m = cmp_op_mask_u16::<{ _MM_CMPINT_LE }>(a, b);
 /// assert_eq!(m, u32::MAX);
 /// ```
 /// * **Intrinsic:** `_mm512_cmp_epu16_mask`
@@ -1222,7 +1222,7 @@ pub fn cmp_op_mask_u16<const OP: i32>(a: m512i, b: m512i) -> mmask32 {
 /// let a = set_splat_i32_m512i(5);
 /// let b = set_splat_i32_m512i(2);
 /// // signed > → 5>2
-/// let m = cmp_op_mask_i32::<{ ::core::arch::x86_64::_MM_CMPINT_LT }>(b, a);
+/// let m = cmp_op_mask_i32::<{ _MM_CMPINT_LT }>(b, a);
 /// assert_eq!(m, u16::MAX);
 /// ```
 /// * **Intrinsic:** `_mm512_cmp_epi32_mask`
@@ -1239,7 +1239,7 @@ pub fn cmp_op_mask_i32<const OP: i32>(a: m512i, b: m512i) -> mmask16 {
 /// let a = set_splat_i32_m512i(2);
 /// let b = set_splat_i32_m512i(5);
 /// // unsigned < → 2<5
-/// let m = cmp_op_mask_u32::<{ ::core::arch::x86_64::_MM_CMPINT_LT }>(a, b);
+/// let m = cmp_op_mask_u32::<{ _MM_CMPINT_LT }>(a, b);
 /// assert_eq!(m, u16::MAX);
 /// ```
 /// * **Intrinsic:** `_mm512_cmp_epu32_mask`
@@ -1255,7 +1255,7 @@ pub fn cmp_op_mask_u32<const OP: i32>(a: m512i, b: m512i) -> mmask16 {
 /// # use safe_arch::*;
 /// let a = set_splat_i64_m512i(5);
 /// let b = set_splat_i64_m512i(5);
-/// let m = cmp_op_mask_i64::<{ ::core::arch::x86_64::_MM_CMPINT_EQ }>(a, b);
+/// let m = cmp_op_mask_i64::<{ _MM_CMPINT_EQ }>(a, b);
 /// assert_eq!(m, u8::MAX);
 /// ```
 /// * **Intrinsic:** `_mm512_cmp_epi64_mask`
@@ -1272,7 +1272,7 @@ pub fn cmp_op_mask_i64<const OP: i32>(a: m512i, b: m512i) -> mmask8 {
 /// let a = set_splat_i64_m512i(3);
 /// let b = set_splat_i64_m512i(5);
 /// // unsigned <= → 3<=5
-/// let m = cmp_op_mask_u64::<{ ::core::arch::x86_64::_MM_CMPINT_LE }>(a, b);
+/// let m = cmp_op_mask_u64::<{ _MM_CMPINT_LE }>(a, b);
 /// assert_eq!(m, u8::MAX);
 /// ```
 /// * **Intrinsic:** `_mm512_cmp_epu64_mask`
@@ -1289,7 +1289,7 @@ pub fn cmp_op_mask_u64<const OP: i32>(a: m512i, b: m512i) -> mmask8 {
 /// let a = set_splat_m512(3.0);
 /// let b = set_splat_m512(5.0);
 /// // < : 3<5
-/// let m = cmp_op_mask_f32::<{ ::core::arch::x86_64::_MM_CMPINT_LT }>(a, b);
+/// let m = cmp_op_mask_f32::<{ _MM_CMPINT_LT }>(a, b);
 /// assert_eq!(m, u16::MAX);
 /// ```
 /// * **Intrinsic:** `_mm512_cmp_ps_mask`
@@ -1305,7 +1305,7 @@ pub fn cmp_op_mask_f32<const OP: i32>(a: m512, b: m512) -> mmask16 {
 /// # use safe_arch::*;
 /// let a = set_splat_m512d(3.0);
 /// let b = set_splat_m512d(3.0);
-/// let m = cmp_op_mask_f64::<{ ::core::arch::x86_64::_MM_CMPINT_EQ }>(a, b);
+/// let m = cmp_op_mask_f64::<{ _MM_CMPINT_EQ }>(a, b);
 /// assert_eq!(m, u8::MAX);
 /// ```
 /// * **Intrinsic:** `_mm512_cmp_pd_mask`
@@ -1325,7 +1325,7 @@ pub fn cmp_op_mask_f64<const OP: i32>(a: m512d, b: m512d) -> mmask8 {
 /// # use safe_arch::*;
 /// let a = set_splat_i8_m512i(5);
 /// let b = set_splat_i8_m512i(5);
-/// let v = cmp_op_mask_i8_m512i::<{ ::core::arch::x86_64::_MM_CMPINT_EQ }>(a, b);
+/// let v = cmp_op_mask_i8_m512i::<{ _MM_CMPINT_EQ }>(a, b);
 /// assert_eq!(v, set_splat_i8_m512i(-1));
 /// ```
 /// * **Intrinsic:** `_mm512_cmp_epi8_mask`, `_mm512_maskz_mov_epi8`
@@ -1342,7 +1342,7 @@ pub fn cmp_op_mask_i8_m512i<const OP: i32>(a: m512i, b: m512i) -> m512i {
 /// # use safe_arch::*;
 /// let a = set_splat_i8_m512i(3);
 /// let b = set_splat_i8_m512i(5);
-/// let v = cmp_op_mask_u8_m512i::<{ ::core::arch::x86_64::_MM_CMPINT_LT }>(a, b);
+/// let v = cmp_op_mask_u8_m512i::<{ _MM_CMPINT_LT }>(a, b);
 /// assert_eq!(v, set_splat_i8_m512i(-1));
 /// ```
 /// * **Intrinsic:** `_mm512_cmp_epu8_mask`, `_mm512_maskz_mov_epi8`
@@ -1359,7 +1359,7 @@ pub fn cmp_op_mask_u8_m512i<const OP: i32>(a: m512i, b: m512i) -> m512i {
 /// # use safe_arch::*;
 /// let a = set_splat_i16_m512i(5);
 /// let b = set_splat_i16_m512i(5);
-/// let v = cmp_op_mask_i16_m512i::<{ ::core::arch::x86_64::_MM_CMPINT_EQ }>(a, b);
+/// let v = cmp_op_mask_i16_m512i::<{ _MM_CMPINT_EQ }>(a, b);
 /// assert_eq!(v, set_splat_i16_m512i(-1));
 /// ```
 /// * **Intrinsic:** `_mm512_cmp_epi16_mask`, `_mm512_maskz_mov_epi16`
@@ -1376,7 +1376,7 @@ pub fn cmp_op_mask_i16_m512i<const OP: i32>(a: m512i, b: m512i) -> m512i {
 /// # use safe_arch::*;
 /// let a = set_splat_i16_m512i(3);
 /// let b = set_splat_i16_m512i(5);
-/// let v = cmp_op_mask_u16_m512i::<{ ::core::arch::x86_64::_MM_CMPINT_LE }>(a, b);
+/// let v = cmp_op_mask_u16_m512i::<{ _MM_CMPINT_LE }>(a, b);
 /// assert_eq!(v, set_splat_i16_m512i(-1));
 /// ```
 /// * **Intrinsic:** `_mm512_cmp_epu16_mask`, `_mm512_maskz_mov_epi16`
@@ -1393,7 +1393,7 @@ pub fn cmp_op_mask_u16_m512i<const OP: i32>(a: m512i, b: m512i) -> m512i {
 /// # use safe_arch::*;
 /// let a = set_splat_i32_m512i(5);
 /// let b = set_splat_i32_m512i(2);
-/// let v = cmp_op_mask_i32_m512i::<{ ::core::arch::x86_64::_MM_CMPINT_LT }>(b, a);
+/// let v = cmp_op_mask_i32_m512i::<{ _MM_CMPINT_LT }>(b, a);
 /// assert_eq!(v, set_splat_i32_m512i(-1));
 /// ```
 /// * **Intrinsic:** `_mm512_cmp_epi32_mask`, `_mm512_maskz_mov_epi32`
@@ -1410,7 +1410,7 @@ pub fn cmp_op_mask_i32_m512i<const OP: i32>(a: m512i, b: m512i) -> m512i {
 /// # use safe_arch::*;
 /// let a = set_splat_i32_m512i(2);
 /// let b = set_splat_i32_m512i(5);
-/// let v = cmp_op_mask_u32_m512i::<{ ::core::arch::x86_64::_MM_CMPINT_LT }>(a, b);
+/// let v = cmp_op_mask_u32_m512i::<{ _MM_CMPINT_LT }>(a, b);
 /// assert_eq!(v, set_splat_i32_m512i(-1));
 /// ```
 /// * **Intrinsic:** `_mm512_cmp_epu32_mask`, `_mm512_maskz_mov_epi32`
@@ -1427,7 +1427,7 @@ pub fn cmp_op_mask_u32_m512i<const OP: i32>(a: m512i, b: m512i) -> m512i {
 /// # use safe_arch::*;
 /// let a = set_splat_i64_m512i(5);
 /// let b = set_splat_i64_m512i(5);
-/// let v = cmp_op_mask_i64_m512i::<{ ::core::arch::x86_64::_MM_CMPINT_EQ }>(a, b);
+/// let v = cmp_op_mask_i64_m512i::<{ _MM_CMPINT_EQ }>(a, b);
 /// assert_eq!(v, set_splat_i64_m512i(-1));
 /// ```
 /// * **Intrinsic:** `_mm512_cmp_epi64_mask`, `_mm512_maskz_mov_epi64`
@@ -1444,7 +1444,7 @@ pub fn cmp_op_mask_i64_m512i<const OP: i32>(a: m512i, b: m512i) -> m512i {
 /// # use safe_arch::*;
 /// let a = set_splat_i64_m512i(3);
 /// let b = set_splat_i64_m512i(5);
-/// let v = cmp_op_mask_u64_m512i::<{ ::core::arch::x86_64::_MM_CMPINT_LE }>(a, b);
+/// let v = cmp_op_mask_u64_m512i::<{ _MM_CMPINT_LE }>(a, b);
 /// assert_eq!(v, set_splat_i64_m512i(-1));
 /// ```
 /// * **Intrinsic:** `_mm512_cmp_epu64_mask`, `_mm512_maskz_mov_epi64`
@@ -1461,7 +1461,7 @@ pub fn cmp_op_mask_u64_m512i<const OP: i32>(a: m512i, b: m512i) -> m512i {
 /// # use safe_arch::*;
 /// let a = set_splat_m512(3.0);
 /// let b = set_splat_m512(5.0);
-/// let v = cmp_op_mask_m512::<{ ::core::arch::x86_64::_MM_CMPINT_LT }>(a, b);
+/// let v = cmp_op_mask_m512::<{ _MM_CMPINT_LT }>(a, b);
 /// assert_eq!(v.to_bits(), [u32::MAX; 16]);
 /// ```
 /// * **Intrinsic:** `_mm512_cmp_ps_mask`, `_mm512_maskz_mov_ps`
@@ -1481,7 +1481,7 @@ pub fn cmp_op_mask_m512<const OP: i32>(a: m512, b: m512) -> m512 {
 /// # use safe_arch::*;
 /// let a = set_splat_m512d(3.0);
 /// let b = set_splat_m512d(3.0);
-/// let v = cmp_op_mask_m512d::<{ ::core::arch::x86_64::_MM_CMPINT_EQ }>(a, b);
+/// let v = cmp_op_mask_m512d::<{ _MM_CMPINT_EQ }>(a, b);
 /// assert_eq!(v.to_bits(), [u64::MAX; 8]);
 /// ```
 /// * **Intrinsic:** `_mm512_cmp_pd_mask`, `_mm512_maskz_mov_pd`
@@ -3397,11 +3397,11 @@ pub fn permute_i32_m512i(idx: m512i, a: m512i) -> m512i {
 ///     3.5, -3.5,  4.1, -4.9,
 /// ]);
 /// // Round to nearest, suppress exceptions
-/// let r_nearest: [f64; 8] = round_m512d::<{ core::arch::x86_64::_MM_FROUND_TO_NEAREST_INT | core::arch::x86_64::_MM_FROUND_NO_EXC }>(a).into();
+/// let r_nearest: [f64; 8] = round_m512d::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a).into();
 /// assert_eq!(r_nearest, [1.0, 3.0, -1.0, -3.0, 4.0, -4.0, 4.0, -5.0]);
 ///
 /// // Round toward zero, suppress exceptions
-/// let r_zero: [f64; 8] = round_m512d::<{ core::arch::x86_64::_MM_FROUND_TO_ZERO | core::arch::x86_64::_MM_FROUND_NO_EXC }>(a).into();
+/// let r_zero: [f64; 8] = round_m512d::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(a).into();
 /// assert_eq!(r_zero, [1.0, 2.0, -1.0, -2.0, 3.0, -3.0, 4.0, -4.0]);
 /// ```
 /// * **Intrinsic:** [`_mm512_roundscale_pd`]
@@ -3425,11 +3425,11 @@ pub fn round_m512d<const OP: i32>(a: m512d) -> m512d {
 ///     7.9, -7.9,  8.4, -8.4,
 /// ]);
 /// // Round to nearest, suppress exceptions
-/// let r_nearest: [f32; 16] = round_m512::<{ core::arch::x86_64::_MM_FROUND_TO_NEAREST_INT | core::arch::x86_64::_MM_FROUND_NO_EXC }>(a).into();
+/// let r_nearest: [f32; 16] = round_m512::<{ _MM_FROUND_TO_NEAREST_INT | _MM_FROUND_NO_EXC }>(a).into();
 /// assert_eq!(&r_nearest[0..4], &[1.0, 3.0, -1.0, -3.0]);
 ///
 /// // Round toward zero, suppress exceptions
-/// let r_zero: [f32; 16] = round_m512::<{ core::arch::x86_64::_MM_FROUND_TO_ZERO | core::arch::x86_64::_MM_FROUND_NO_EXC }>(a).into();
+/// let r_zero: [f32; 16] = round_m512::<{ _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC }>(a).into();
 /// assert_eq!(&r_zero[0..4], &[1.0, 2.0, -1.0, -2.0]);
 /// ```
 /// * **Intrinsic:** [`_mm512_roundscale_ps`]


### PR DESCRIPTION
This should (hopefully) fix the sporadic compile failure on CI.

+a lot of trailing whitespace removal done by my editor.